### PR TITLE
Remove auto-shutdown from get coco script

### DIFF
--- a/data/get_coco_dataset.sh
+++ b/data/get_coco_dataset.sh
@@ -27,8 +27,6 @@ unzip -q instances_train-val2014.zip
 paste <(awk "{print \"$PWD\"}" <5k.part) 5k.part | tr -d '\t' > 5k.txt
 paste <(awk "{print \"$PWD\"}" <trainvalno5k.part) trainvalno5k.part | tr -d '\t' > trainvalno5k.txt
 
-sudo shutdown
-
 # get xview training data
 # wget -O train_images.tgz 'https://d307kc0mrhucc3.cloudfront.net/train_images.tgz?Expires=1530124049&Signature=JrQoxipmsETvb7eQHCfDFUO-QEHJGAayUv0i-ParmS-1hn7hl9D~bzGuHWG82imEbZSLUARTtm0wOJ7EmYMGmG5PtLKz9H5qi6DjoSUuFc13NQ-~6yUhE~NfPaTnehUdUMCa3On2wl1h1ZtRG~0Jq1P-AJbpe~oQxbyBrs1KccaMa7FK4F4oMM6sMnNgoXx8-3O77kYw~uOpTMFmTaQdHln6EztW0Lx17i57kK3ogbSUpXgaUTqjHCRA1dWIl7PY1ngQnLslkLhZqmKcaL-BvWf0ZGjHxCDQBpnUjIlvMu5NasegkwD9Jjc0ClgTxsttSkmbapVqaVC8peR0pO619Q__&Key-Pair-Id=APKAIKGDJB5C3XUL2DXQ'
 # tar -xvzf train_images.tgz


### PR DESCRIPTION
This is presumably for unattended download on cloud systems, but the script should alert the user first. Automatically shutting down a system when you download some data shouldn't be default behaviour. It's also not in the original Darknet script (https://github.com/pjreddie/darknet/blob/master/scripts/get_coco_dataset.sh).

Alternatively run `get_coco_dataset.sh && sudo shutdown`.