### PR TITLE
Save model by default

### DIFF
--- a/train.py
+++ b/train.py
@@ -170,7 +170,6 @@ def train(
             best_loss = mloss['total']
 
         # Save training results
-        save = False
         if save:
             # Save latest checkpoint
             checkpoint = {'epoch': epoch,

--- a/train.py
+++ b/train.py
@@ -170,6 +170,7 @@ def train(
             best_loss = mloss['total']
 
         # Save training results
+        save = True
         if save:
             # Save latest checkpoint
             checkpoint = {'epoch': epoch,


### PR DESCRIPTION
A recent change made it such that train.py doesn't save models by default. This is counter-intuitive, and would make users train to completion only to realize everything is gone (exhibit A: myself 🙃). 