### PR TITLE
Encoding of video output - Resolves Issue 243

### DIFF
--- a/detect.py
+++ b/detect.py
@@ -104,11 +104,10 @@ def detect(
                     if isinstance(vid_writer, cv2.VideoWriter):
                         vid_writer.release()  # release previous video writer
 
-                    codec = int(vid_cap.get(cv2.CAP_PROP_FOURCC))
                     fps = vid_cap.get(cv2.CAP_PROP_FPS)
                     width = int(vid_cap.get(cv2.CAP_PROP_FRAME_WIDTH))
                     height = int(vid_cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
-                    vid_writer = cv2.VideoWriter(save_path, codec, fps, (width, height))
+                    vid_writer = cv2.VideoWriter(save_path, cv2.VideoWriter_fourcc(*'mp4v'), fps, (width, height))
                 vid_writer.write(im0)
 
     if save_images:

--- a/detect.py
+++ b/detect.py
@@ -13,6 +13,7 @@ def detect(
         weights,
         images='data/samples',  # input folder
         output='output',  # output folder
+        fourcc='mp4v',
         img_size=416,
         conf_thres=0.5,
         nms_thres=0.5,
@@ -107,7 +108,7 @@ def detect(
                     fps = vid_cap.get(cv2.CAP_PROP_FPS)
                     width = int(vid_cap.get(cv2.CAP_PROP_FRAME_WIDTH))
                     height = int(vid_cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
-                    vid_writer = cv2.VideoWriter(save_path, cv2.VideoWriter_fourcc(*'mp4v'), fps, (width, height))
+                    vid_writer = cv2.VideoWriter(save_path, cv2.VideoWriter_fourcc(*fourcc), fps, (width, height))
                 vid_writer.write(im0)
 
     if save_images:
@@ -125,6 +126,8 @@ if __name__ == '__main__':
     parser.add_argument('--img-size', type=int, default=416, help='inference size (pixels)')
     parser.add_argument('--conf-thres', type=float, default=0.5, help='object confidence threshold')
     parser.add_argument('--nms-thres', type=float, default=0.5, help='iou threshold for non-maximum suppression')
+    parser.add_argument('--fourcc', type=str, default='mp4v', help='specifies the fourcc code for output video encoding (make sure ffmpeg supports specified fourcc codec)')
+    parser.add_argument('--output', type=str, default='output',help='specifies the output path for images and videos')
     opt = parser.parse_args()
     print(opt)
 
@@ -136,5 +139,7 @@ if __name__ == '__main__':
             images=opt.images,
             img_size=opt.img_size,
             conf_thres=opt.conf_thres,
-            nms_thres=opt.nms_thres
+            nms_thres=opt.nms_thres,
+            fourcc=opt.fourcc,
+            output=opt.output
         )


### PR DESCRIPTION
Resolves #243 

Added two more arguments for users to specify output file encoding and output file directory. Then I changed the default FourCC code which is known to work on Windows and Linux. It should also work on Mac, but I have not verified this personally but people a couple of StackOverflow threads suggest mpv4 works with QTkit.

## Ubuntu Verification
![verification_ubuntu2](https://user-images.githubusercontent.com/43619961/57794793-12c83600-770a-11e9-8892-30a05dbab54e.png)
![verification_ubuntu](https://user-images.githubusercontent.com/43619961/57794797-152a9000-770a-11e9-8fdc-d20fd878c0fd.png)

## Windows Verification

![windows_verification](https://user-images.githubusercontent.com/43619961/57795267-245e0d80-770b-11e9-8c40-5101035984b8.PNG)
![windows_verification2](https://user-images.githubusercontent.com/43619961/57795275-27f19480-770b-11e9-8422-92b1fd4b22c2.PNG)

