### PR TITLE
update parse_model_cfg()

### DIFF
--- a/utils/parse_config.py
+++ b/utils/parse_config.py
@@ -9,6 +9,8 @@ def parse_model_cfg(path):
         if line.startswith('['):  # This marks the start of a new block
             module_defs.append({})
             module_defs[-1]['type'] = line[1:-1].rstrip()
+            if module_defs[-1]['type'] == 'convolutional':
+                module_defs[-1]['batch_normalize'] = 0
         else:
             key, value = line.split("=")
             value = value.strip()


### PR DESCRIPTION
Removing the two lines for adding batch_normalize key to convolutional layers causes the parsing of the model to break when parsing it in models.py