### PR TITLE
changed a interpolation method for Down/Upsampling

### DIFF
--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -366,7 +366,7 @@ def letterbox(img, new_shape=416, color=(127.5, 127.5, 127.5), mode='auto'):
 
     top, bottom = int(round(dh - 0.1)), int(round(dh + 0.1))
     left, right = int(round(dw - 0.1)), int(round(dw + 0.1))
-    img = cv2.resize(img, new_unpad, interpolation=cv2.INTER_LINEAR)  # resized, no border
+    img = cv2.resize(img, new_unpad, interpolation=cv2.INTER_CUBIC)  # resized, no border
     img = cv2.copyMakeBorder(img, top, bottom, left, right, cv2.BORDER_CONSTANT, value=color)  # padded square
     return img, ratiow, ratioh, dw, dh
 
@@ -400,7 +400,7 @@ def random_affine(img, targets=(), degrees=(-10, 10), translate=(.1, .1), scale=
     S[1, 0] = math.tan((random.random() * (shear[1] - shear[0]) + shear[0]) * math.pi / 180)  # y shear (deg)
 
     M = S @ T @ R  # Combined rotation matrix. ORDER IS IMPORTANT HERE!!
-    imw = cv2.warpAffine(img, M[:2], dsize=(width, height), flags=cv2.INTER_LINEAR,
+    imw = cv2.warpAffine(img, M[:2], dsize=(width, height), flags=cv2.INTER_CUBIC,
                          borderValue=borderValue)  # BGR order borderValue
 
     # Return warped points also


### PR DESCRIPTION
I changed a interpolation method used in downsampling, upsampling and affine transform.

Bicubic interpolation method normally outperformed a linear interpolation method in terms of PSNR and subjective quality and many researches for Super Resolution method have adopted this to upsample and downsample the image.
 
But... it's not a critical issue.

What do you think of this??