### PR TITLE
Modify build_targets for the test

### DIFF
--- a/utils/utils.py
+++ b/utils/utils.py
@@ -365,7 +365,7 @@ def build_targets(model, targets):
                 iou = iou.view(-1)  # use all ious
 
             # reject anchors below iou_thres (OPTIONAL, increases P, lowers R)
-            reject = True
+            reject = True if model.training else False
             if reject:
                 j = iou > model.hyp['iou_t']  # iou threshold hyperparameter
                 t, a, gwh = t[j], a[j], gwh[j]


### PR DESCRIPTION
When I trained and tested custom model with custom dataset, I had got NaN loss error during the test.

That problem is caused by reject flag that used for model to be trained with object size has proper IOU in training process. 

I removed that flag and condition and then that problem is solved.

It seems like to cause NaN loss during the test if we do not have enough anchors to compatible with the size of bounding box in test dataset.

So I added the condition to neglect reject flag during the test.

What do you think of this?