### PR TITLE
add json hyperparams loading

### DIFF
--- a/train.py
+++ b/train.py
@@ -45,7 +45,14 @@ f = glob.glob('hyp*.txt')
 if f:
     for k, v in zip(hyp.keys(), np.loadtxt(f[0])):
         hyp[k] = v
-
+        
+json_hypers = glob.glob("hyp*.json")
+if json_hypers:
+    import json
+    with open(json_hypers[0]) as f:
+        loaded_hyp = json.load(f)
+    for k, v in loaded_hyp.items():
+        hyp[k] = v
 
 def train():
     cfg = opt.cfg


### PR DESCRIPTION
This would allow us to load hyperparams from a json file and only override the defaults params that are in the json file instead of having to have the exact lines placed in the correct order in a .txt hyperparam file.

This could replace the other method of loading hyperparams, I left it there because I guess some people are uding it. A json file would be more flexible and more readable I think