### PR TITLE
fusedconv bug fix

### DIFF
--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -61,7 +61,7 @@ def fuse_conv_and_bn(conv, bn):
         else:
             b_conv = torch.zeros(conv.weight.size(0))
         b_bn = bn.bias - bn.weight.mul(bn.running_mean).div(torch.sqrt(bn.running_var + bn.eps))
-        fusedconv.bias.copy_(b_conv + b_bn)
+        fusedconv.bias.copy_(torch.mm(w_bn, b_conv.reshape(-1, 1)).reshape(-1) + b_bn)
 
         return fusedconv
 


### PR DESCRIPTION
Fix the conv-fuse bug when `Conv2d()` layers have `bias=True` and followed by batchnorm layers.
More details in https://github.com/ultralytics/yolov3/issues/807.