### PR TITLE
Fix argparse string escapes in train.py.

### DIFF
--- a/train.py
+++ b/train.py
@@ -386,7 +386,7 @@ if __name__ == '__main__':
     parser.add_argument('--accumulate', type=int, default=4, help='batches to accumulate before optimizing')
     parser.add_argument('--cfg', type=str, default='cfg/yolov3-spp.cfg', help='*.cfg path')
     parser.add_argument('--data', type=str, default='data/coco2017.data', help='*.data path')
-    parser.add_argument('--multi-scale', action='store_true', help='adjust (67% - 150%) img_size every 10 batches')
+    parser.add_argument('--multi-scale', action='store_true', help='adjust (67%% - 150%%) img_size every 10 batches')
     parser.add_argument('--img-size', nargs='+', type=int, default=[416], help='train and test image-sizes')
     parser.add_argument('--rect', action='store_true', help='rectangular training')
     parser.add_argument('--resume', action='store_true', help='resume training from last.pt')


### PR DESCRIPTION
Without the attached change, I get an error displaying help:

```$ python train.py --help                                                                     
Traceback (most recent call last):
  File "train.py", line 403, in <module>
    opt = parser.parse_args()
  File "/ascldap/users/tshead/miniconda3/lib/python3.7/argparse.py", line 1755, in parse_args
    args, argv = self.parse_known_args(args, namespace)
  File "/ascldap/users/tshead/miniconda3/lib/python3.7/argparse.py", line 1787, in parse_known_args
    namespace, args = self._parse_known_args(args, namespace)
  File "/ascldap/users/tshead/miniconda3/lib/python3.7/argparse.py", line 1993, in _parse_known_args
    start_index = consume_optional(start_index)
  File "/ascldap/users/tshead/miniconda3/lib/python3.7/argparse.py", line 1933, in consume_optional
    take_action(action, args, option_string)
  File "/ascldap/users/tshead/miniconda3/lib/python3.7/argparse.py", line 1861, in take_action
    action(self, namespace, argument_values, option_string)
  File "/ascldap/users/tshead/miniconda3/lib/python3.7/argparse.py", line 1043, in __call__
    parser.print_help()
  File "/ascldap/users/tshead/miniconda3/lib/python3.7/argparse.py", line 2481, in print_help
    self._print_message(self.format_help(), file)
  File "/ascldap/users/tshead/miniconda3/lib/python3.7/argparse.py", line 2465, in format_help
    return formatter.format_help()
  File "/ascldap/users/tshead/miniconda3/lib/python3.7/argparse.py", line 284, in format_help
    help = self._root_section.format_help()
  File "/ascldap/users/tshead/miniconda3/lib/python3.7/argparse.py", line 215, in format_help
    item_help = join([func(*args) for func, args in self.items])
  File "/ascldap/users/tshead/miniconda3/lib/python3.7/argparse.py", line 215, in <listcomp>
    item_help = join([func(*args) for func, args in self.items])
  File "/ascldap/users/tshead/miniconda3/lib/python3.7/argparse.py", line 215, in format_help
    item_help = join([func(*args) for func, args in self.items])
  File "/ascldap/users/tshead/miniconda3/lib/python3.7/argparse.py", line 215, in <listcomp>
    item_help = join([func(*args) for func, args in self.items])
  File "/ascldap/users/tshead/miniconda3/lib/python3.7/argparse.py", line 531, in _format_action
    help_text = self._expand_help(action)
  File "/ascldap/users/tshead/miniconda3/lib/python3.7/argparse.py", line 620, in _expand_help
    return self._get_help_string(action) % params
ValueError: unsupported format character '%' (0x25) at index 17
```