### PR TITLE
fix: resume training epoch error

### DIFF
--- a/train.py
+++ b/train.py
@@ -220,7 +220,7 @@ def train():
     t0 = time.time()
     print('Using %g dataloader workers' % nw)
     print('Starting training for %g epochs...' % epochs)
-    for epoch in range(start_epoch, epochs):  # epoch ------------------------------------------------------------------
+    for epoch in range(start_epoch, start_epoch + epochs):  # epoch ------------------------------------------------------------------
         model.train()
 
         # Update image weights (optional)
@@ -286,7 +286,7 @@ def train():
             # Print batch results
             mloss = (mloss * i + loss_items) / (i + 1)  # update mean losses
             mem = '%.3gG' % (torch.cuda.memory_cached() / 1E9 if torch.cuda.is_available() else 0)  # (GB)
-            s = ('%10s' * 2 + '%10.3g' * 6) % ('%g/%g' % (epoch, epochs - 1), mem, *mloss, len(targets), img_size)
+            s = ('%10s' * 2 + '%10.3g' * 6) % ('%g/%g' % (epoch, start_epoch + epochs - 1), mem, *mloss, len(targets), img_size)
             pbar.set_description(s)
 
             # Plot images with bounding boxes


### PR DESCRIPTION
In the case of resume training, the start_epoch was more than epochs itself, which breaks 
the training before starting it after comparison (start_epoch, epochs)