### PR TITLE
add tensorboard to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ matplotlib
 pycocotools
 tqdm
 pillow
+tensorboard >= 1.14
 
 # Nvidia Apex (optional) for mixed precision training --------------------------
 # git clone https://github.com/NVIDIA/apex && cd apex && pip install -v --no-cache-dir --global-option="--cpp_ext" --global-option="--cuda_ext" . --user && cd .. && rm -rf apex


### PR DESCRIPTION
In a clean environment running training fails if tensorboard is not installed e.g.

```
Traceback (most recent call last):
  File "/home/josh/miniconda3/envs/ultralytics/lib/python3.7/site-packages/torch/utils/tensorboard/__init__.py", line 2, in <module>
    from tensorboard.summary.writer.record_writer import RecordWriter  # noqa F401
ModuleNotFoundError: No module named 'tensorboard'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "train.py", line 6, in <module>
    from torch.utils.tensorboard import SummaryWriter
  File "/home/josh/miniconda3/envs/ultralytics/lib/python3.7/site-packages/torch/utils/tensorboard/__init__.py", line 4, in <module>
    raise ImportError('TensorBoard logging requires TensorBoard with Python summary writer installed. '
ImportError: TensorBoard logging requires TensorBoard with Python summary writer installed. This should be available in 1.14 or above.
```