### PR TITLE
Fix compatibility with Yolo V2 version

### DIFF
--- a/utils/parse_config.py
+++ b/utils/parse_config.py
@@ -40,7 +40,8 @@ def parse_model_cfg(path):
     supported = ['type', 'batch_normalize', 'filters', 'size', 'stride', 'pad', 'activation', 'layers', 'groups',
                  'from', 'mask', 'anchors', 'classes', 'num', 'jitter', 'ignore_thresh', 'truth_thresh', 'random',
                  'stride_x', 'stride_y', 'weights_type', 'weights_normalization', 'scale_x_y', 'beta_nms', 'nms_kind',
-                 'iou_loss', 'iou_normalizer', 'cls_normalizer', 'iou_thresh']
+                 'iou_loss', 'iou_normalizer', 'cls_normalizer', 'iou_thresh', 'bias_match', 'coords', 'softmax',
+                 'rescore', 'object_scale', 'noobject_scale', 'class_scale', 'coord_scale', 'absolute', 'thresh']
 
     f = []  # fields
     for x in mdefs[1:]:

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -576,7 +576,7 @@ def non_max_suppression(prediction, conf_thres=0.1, iou_thres=0.6, multi_label=T
 
 
 def get_yolo_layers(model):
-    bool_vec = [x['type'] == 'yolo' for x in model.module_defs]
+    bool_vec = [x['type'] == 'yolo' or x['type'] == 'region' for x in model.module_defs]
     return [i for i, x in enumerate(bool_vec) if x]  # [82, 94, 106] for yolov3
 
 


### PR DESCRIPTION
Fix compatibility with Yolo V2 version
- added [region] (old version of Yolo, with its parameters) and [reorg] layers support
- remove silent ignorance of reorg3d (it does not work in this way)
- fixed binary compatibility with old versions of *.weights files
