### PR TITLE
fixes broken numpy build in ubuntu 20.04; adds dev requirements

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,7 @@
+# pip install -U -r requirements-dev.txt
+
+# include the runtime requirements
+-r requirements.txt
+
+# add development requirements here
+torchvision>=0.6.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # pip install -U -r requirements.txt
 # pycocotools requires numpy 1.17 https://github.com/cocodataset/cocoapi/issues/356
-numpy == 1.17
+numpy == 1.19
 opencv-python >= 4.1
 torch >= 1.5
 matplotlib


### PR DESCRIPTION
I'm building on 20.04 and hit an error on pip install. Error message was:
  numpy/random/entropy.c:23684:15: error: ‘__Pyx_PyCode_New’ undeclared
There were several recommendations to do a numpy install direct from a git commit, but it turns out there was a release this weekend, so I simply upgraded the numpy version to fix that issue.

Also, when running 
  python detect.py
torchvision was missing.  So I've started a dev requirements file, so that we can put dev-time clutter in there, and make a runtime build lighter.