### PR TITLE
Fixed string format error during weight conversion

### DIFF
--- a/models.py
+++ b/models.py
@@ -438,7 +438,7 @@ def convert(cfg='cfg/yolov3-spp.cfg', weights='weights/yolov3-spp.weights'):
 
         target = weights.rsplit('.', 1)[0] + '.pt'
         torch.save(chkpt, target)
-        print("Success: converted '%s' to 's%'" % (weights, target))
+        print("Success: converted '%s' to '%s'" % (weights, target))
 
     else:
         print('Error: extension not supported.')


### PR DESCRIPTION
## What

Fixing the typo in format string in the commit. Tested that now it converts without error and prints out success message.

## Why

Fix the error during weight conversion between PyTorch weights and darknet weights.

## Reference

Issue #1247