### PR TITLE
Modify DataLoader

### DIFF
--- a/train.py
+++ b/train.py
@@ -205,7 +205,7 @@ def train(hyp):
                                              num_workers=nw,
                                              shuffle=not opt.rect,  # Shuffle=True unless rectangular training is used
                                              pin_memory=True,
-                                             collate_fn=dataset.collate_fn)
+                                             collate_fn=dataset.collate_fn, drop_last = True)
 
     # Testloader
     testloader = torch.utils.data.DataLoader(LoadImagesAndLabels(test_path, imgsz_test, batch_size,
@@ -216,7 +216,7 @@ def train(hyp):
                                              batch_size=batch_size,
                                              num_workers=nw,
                                              pin_memory=True,
-                                             collate_fn=dataset.collate_fn)
+                                             collate_fn=dataset.collate_fn, drop_last = True)
 
     # Model parameters
     model.nc = nc  # attach number of classes to model

--- a/train.py
+++ b/train.py
@@ -205,7 +205,7 @@ def train(hyp):
                                              num_workers=nw,
                                              shuffle=not opt.rect,  # Shuffle=True unless rectangular training is used
                                              pin_memory=True,
-                                             collate_fn=dataset.collate_fn, drop_last = True)
+                                             collate_fn=dataset.collate_fn, drop_last = True) # drop_last = True
 
     # Testloader
     testloader = torch.utils.data.DataLoader(LoadImagesAndLabels(test_path, imgsz_test, batch_size,
@@ -216,7 +216,7 @@ def train(hyp):
                                              batch_size=batch_size,
                                              num_workers=nw,
                                              pin_memory=True,
-                                             collate_fn=dataset.collate_fn, drop_last = True)
+                                             collate_fn=dataset.collate_fn, drop_last = True)  # drop_last = True
 
     # Model parameters
     model.nc = nc  # attach number of classes to model


### PR DESCRIPTION
The DataLoader of the original code had a problem that the number of data had to be divided by Batchsize.
so often an error occurred.   

Like this 
("TypeError: forward() missing 1 required positional argument: 'x')
https://github.com/ultralytics/yolov3/issues/1355
https://github.com/ultralytics/yolov3/issues/1074

But add  "drop_last = True" in DataLoader, the problem is fixed.

I tested this code in a "multi-GPU environment"