### PR TITLE
Modify Line 104 on getting coco dataset

### DIFF
--- a/tutorial.ipynb
+++ b/tutorial.ipynb
@@ -101,7 +101,7 @@
    ],
    "source": [
     "!git clone https://github.com/ultralytics/yolov3  # clone\n",
-    "!bash yolov3/data/get_coco_dataset_gdrive.sh  # copy COCO2014 dataset (19GB)\n",
+    "!bash yolov3/data/get_coco2014.sh  # copy COCO2014 dataset (19GB)\n",
     "%cd yolov3"
    ]
   },


### PR DESCRIPTION
The correct command for downloading coco dataset 2014 is supposed to be "!bash yolov3/data/get_coco2014.sh"