### PR TITLE
Add bias to Classify()

### DIFF
--- a/models/common.py
+++ b/models/common.py
@@ -1,7 +1,6 @@
 # This file contains modules common to various models
 
 import math
-
 import numpy as np
 import torch
 import torch.nn as nn
@@ -244,7 +243,7 @@ class Classify(nn.Module):
     def __init__(self, c1, c2, k=1, s=1, p=None, g=1):  # ch_in, ch_out, kernel, stride, padding, groups
         super(Classify, self).__init__()
         self.aap = nn.AdaptiveAvgPool2d(1)  # to x(b,c1,1,1)
-        self.conv = nn.Conv2d(c1, c2, k, s, autopad(k, p), groups=g, bias=False)  # to x(b,c2,1,1)
+        self.conv = nn.Conv2d(c1, c2, k, s, autopad(k, p), groups=g)  # to x(b,c2,1,1)
         self.flat = Flatten()
 
     def forward(self, x):


### PR DESCRIPTION
This PR adds the default nn.Conv2d() bias to the Classify() head, fixing a minor mistake.

