### PR TITLE
Normalized mosaic plotting bug fix

### DIFF
--- a/utils/plots.py
+++ b/utils/plots.py
@@ -141,7 +141,7 @@ def plot_images(images, targets, paths=None, fname='images.jpg', names=None, max
             conf = None if labels else image_targets[:, 6]  # check for confidence presence (label vs pred)
 
             if boxes.shape[1]:
-                if boxes.max() <= 1:  # if normalized
+                if boxes.max() <= 1.01:  # if normalized with tolerance 0.01
                     boxes[[0, 2]] *= w  # scale to pixels
                     boxes[[1, 3]] *= h
                 elif scale_factor < 1:  # absolute coords need scale if image scales


### PR DESCRIPTION
This PR attempts to fix issue https://github.com/ultralytics/yolov5/issues/1623. A tolerance is introduced to the normalization determination of labels, which previously accidentally classified labels as non-normalized due to numerical precision issues.