### PR TITLE
Update LICENSE to AGPL-3.0

### DIFF
--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -1,4 +1,4 @@
-# YOLOv3 🚀 by Ultralytics, GPL-3.0 license
+# YOLOv3 🚀 by Ultralytics, AGPL-3.0 license
 # YOLOv3 Continuous Integration (CI) GitHub Actions tests
 
 name: YOLOv3 CI

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,4 +1,4 @@
-# YOLOv3 🚀 by Ultralytics, GPL-3.0 license
+# YOLOv3 🚀 by Ultralytics, AGPL-3.0 license
 # Builds ultralytics/yolov5:latest images on DockerHub https://hub.docker.com/r/ultralytics/yolov3
 
 name: Publish Docker Images

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -1,4 +1,4 @@
-# YOLOv3 🚀 by Ultralytics, GPL-3.0 license
+# YOLOv3 🚀 by Ultralytics, AGPL-3.0 license
 
 name: Greetings
 

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,4 +1,4 @@
-# YOLOv3 🚀 by Ultralytics, GPL-3.0 license
+# YOLOv3 🚀 by Ultralytics, AGPL-3.0 license
 
 name: Close stale issues
 on:

--- a/.github/workflows/translate-readme.yml
+++ b/.github/workflows/translate-readme.yml
@@ -1,4 +1,4 @@
-# YOLOv3 🚀 by Ultralytics, GPL-3.0 license
+# YOLOv3 🚀 by Ultralytics, AGPL-3.0 license
 # README translation action to translate README.md to Chinese as README.zh-CN.md on any change to README.md
 
 name: Translate README

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# Ultralytics YOLO 🚀, GPL-3.0 license
+# Ultralytics YOLO 🚀, AGPL-3.0 license
 # Pre-commit hooks. For more information see https://github.com/pre-commit/pre-commit-hooks/blob/main/README.md
 
 exclude: 'docs/'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -10,5 +10,5 @@ preferred-citation:
   version: 7.0
   doi: 10.5281/zenodo.3908559
   date-released: 2020-5-29
-  license: GPL-3.0
+  license: AGPL-3.0
   url: "https://github.com/ultralytics/yolov5"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,4 +90,4 @@ understand and diagnose your problem.
 ## License
 
 By contributing, you agree that your contributions will be licensed under
-the [GPL-3.0 license](https://choosealicense.com/licenses/gpl-3.0/)
+the [AGPL-3.0 license](https://choosealicense.com/licenses/agpl-3.0/)

--- a/LICENSE
+++ b/LICENSE
@@ -1,23 +1,21 @@
-GNU GENERAL PUBLIC LICENSE
-                       Version 3, 29 June 2007
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
 
- Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 
                             Preamble
 
-  The GNU General Public License is a free, copyleft license for
-software and other kinds of works.
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
 
   The licenses for most software and other practical works are designed
 to take away your freedom to share and change the works.  By contrast,
-the GNU General Public License is intended to guarantee your freedom to
+our General Public Licenses are intended to guarantee your freedom to
 share and change all versions of a program--to make sure it remains free
-software for all its users.  We, the Free Software Foundation, use the
-GNU General Public License for most of our software; it applies also to
-any other work released this way by its authors.  You can apply it to
-your programs, too.
+software for all its users.
 
   When we speak of free software, we are referring to freedom, not
 price.  Our General Public Licenses are designed to make sure that you
@@ -26,44 +24,34 @@ them if you wish), that you receive source code or can get it if you
 want it, that you can change the software or use pieces of it in new
 free programs, and that you know you can do these things.
 
-  To protect your rights, we need to prevent others from denying you
-these rights or asking you to surrender the rights.  Therefore, you have
-certain responsibilities if you distribute copies of the software, or if
-you modify it: responsibilities to respect the freedom of others.
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
 
-  For example, if you distribute copies of such a program, whether
-gratis or for a fee, you must pass on to the recipients the same
-freedoms that you received.  You must make sure that they, too, receive
-or can get the source code.  And you must show them these terms so they
-know their rights.
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
 
-  Developers that use the GNU GPL protect your rights with two steps:
-(1) assert copyright on the software, and (2) offer you this License
-giving you legal permission to copy, distribute and/or modify it.
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
 
-  For the developers' and authors' protection, the GPL clearly explains
-that there is no warranty for this free software.  For both users' and
-authors' sake, the GPL requires that modified versions be marked as
-changed, so that their problems will not be attributed erroneously to
-authors of previous versions.
-
-  Some devices are designed to deny users access to install or run
-modified versions of the software inside them, although the manufacturer
-can do so.  This is fundamentally incompatible with the aim of
-protecting users' freedom to change the software.  The systematic
-pattern of such abuse occurs in the area of products for individuals to
-use, which is precisely where it is most unacceptable.  Therefore, we
-have designed this version of the GPL to prohibit the practice for those
-products.  If such problems arise substantially in other domains, we
-stand ready to extend this provision to those domains in future versions
-of the GPL, as needed to protect the freedom of users.
-
-  Finally, every program is threatened constantly by software patents.
-States should not allow patents to restrict development and use of
-software on general-purpose computers, but in those that do, we wish to
-avoid the special danger that patents applied to a free program could
-make it effectively proprietary.  To prevent this, the GPL assures that
-patents cannot be used to render the program non-free.
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
 
   The precise terms and conditions for copying, distribution and
 modification follow.
@@ -72,7 +60,7 @@ modification follow.
 
   0. Definitions.
 
-  "This License" refers to version 3 of the GNU General Public License.
+  "This License" refers to version 3 of the GNU Affero General Public License.
 
   "Copyright" also means copyright-like laws that apply to other kinds of
 works, such as semiconductor masks.
@@ -549,35 +537,45 @@ to collect a royalty for further conveying from those to whom you convey
 the Program, the only way you could satisfy both those terms and this
 License would be to refrain entirely from conveying the Program.
 
-  13. Use with the GNU Affero General Public License.
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
 
   Notwithstanding any other provision of this License, you have
 permission to link or combine any covered work with a work licensed
-under version 3 of the GNU Affero General Public License into a single
+under version 3 of the GNU General Public License into a single
 combined work, and to convey the resulting work.  The terms of this
 License will continue to apply to the part which is the covered work,
-but the special requirements of the GNU Affero General Public License,
-section 13, concerning interaction through a network will apply to the
-combination as such.
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
 
   14. Revised Versions of this License.
 
   The Free Software Foundation may publish revised and/or new versions of
-the GNU General Public License from time to time.  Such new versions will
-be similar in spirit to the present version, but may differ in detail to
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
 address new problems or concerns.
 
   Each version is given a distinguishing version number.  If the
-Program specifies that a certain numbered version of the GNU General
+Program specifies that a certain numbered version of the GNU Affero General
 Public License "or any later version" applies to it, you have the
 option of following the terms and conditions either of that numbered
 version or of any later version published by the Free Software
 Foundation.  If the Program does not specify a version number of the
-GNU General Public License, you may choose any version ever published
+GNU Affero General Public License, you may choose any version ever published
 by the Free Software Foundation.
 
   If the Program specifies that a proxy can decide which future
-versions of the GNU General Public License can be used, that proxy's
+versions of the GNU Affero General Public License can be used, that proxy's
 public statement of acceptance of a version permanently authorizes you
 to choose that version for the Program.
 
@@ -635,40 +633,29 @@ the "copyright" line and a pointer to where the full notice is found.
     Copyright (C) <year>  <name of author>
 
     This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
+    it under the terms of the GNU Affero General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
+    GNU Affero General Public License for more details.
 
-    You should have received a copy of the GNU General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 Also add information on how to contact you by electronic and paper mail.
 
-  If the program does terminal interaction, make it output a short
-notice like this when it starts in an interactive mode:
-
-    <program>  Copyright (C) <year>  <name of author>
-    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
-    This is free software, and you are welcome to redistribute it
-    under certain conditions; type `show c' for details.
-
-The hypothetical commands `show w' and `show c' should show the appropriate
-parts of the General Public License.  Of course, your program's commands
-might be different; for a GUI interface, you would use an "about box".
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
 
   You should also get your employer (if you work as a programmer) or school,
 if any, to sign a "copyright disclaimer" for the program, if necessary.
-For more information on this, and how to apply and follow the GNU GPL, see
-<http://www.gnu.org/licenses/>.
-
-  The GNU General Public License does not permit incorporating your program
-into proprietary programs.  If your program is a subroutine library, you
-may consider it more useful to permit linking proprietary applications with
-the library.  If this is what you want to do, use the GNU Lesser General
-Public License instead of this License.  But first, please read
-<http://www.gnu.org/philosophy/why-not-lgpl.html>.
+For more information on this, and how to apply and follow the GNU AGPL, see
+<https://www.gnu.org/licenses/>.

--- a/README.md
+++ b/README.md
@@ -455,8 +455,8 @@ We love your input! We want to make contributing to YOLOv3 as easy and transpare
 
 YOLOv3 is available under two different licenses:
 
-- **GPL-3.0 License**: See [LICENSE](https://github.com/ultralytics/yolov5/blob/master/LICENSE) file for details.
-- **Enterprise License**: Provides greater flexibility for commercial product development without the open-source requirements of GPL-3.0. Typical use cases are embedding Ultralytics software and AI models in commercial products and applications. Request an Enterprise License at [Ultralytics Licensing](https://ultralytics.com/license).
+- **AGPL-3.0 License**: See [LICENSE](https://github.com/ultralytics/yolov5/blob/master/LICENSE) file for details.
+- **Enterprise License**: Provides greater flexibility for commercial product development without the open-source requirements of AGPL-3.0. Typical use cases are embedding Ultralytics software and AI models in commercial products and applications. Request an Enterprise License at [Ultralytics Licensing](https://ultralytics.com/license).
 
 ## <div align="center">Contact</div>
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -452,8 +452,8 @@ python export.py --weights yolov5s-cls.pt resnet50.pt efficientnet_b0.pt --inclu
 
 YOLOv3 在两种不同的 License 下可用：
 
-- **GPL-3.0 License**： 查看 [License](https://github.com/ultralytics/yolov5/blob/master/LICENSE) 文件的详细信息。
-- **企业License**：在没有 GPL-3.0 开源要求的情况下为商业产品开发提供更大的灵活性。典型用例是将 Ultralytics 软件和 AI 模型嵌入到商业产品和应用程序中。在以下位置申请企业许可证 [Ultralytics 许可](https://ultralytics.com/license) 。
+- **AGPL-3.0 License**： 查看 [License](https://github.com/ultralytics/yolov5/blob/master/LICENSE) 文件的详细信息。
+- **企业License**：在没有 AGPL-3.0 开源要求的情况下为商业产品开发提供更大的灵活性。典型用例是将 Ultralytics 软件和 AI 模型嵌入到商业产品和应用程序中。在以下位置申请企业许可证 [Ultralytics 许可](https://ultralytics.com/license) 。
 
 ## <div align="center">联系我们</div>
 

--- a/benchmarks.py
+++ b/benchmarks.py
@@ -1,4 +1,4 @@
-# YOLOv3 🚀 by Ultralytics, GPL-3.0 license
+# YOLOv3 🚀 by Ultralytics, AGPL-3.0 license
 """
 Run  benchmarks on all supported export formats
 

--- a/classify/predict.py
+++ b/classify/predict.py
@@ -1,4 +1,4 @@
-# YOLOv3 🚀 by Ultralytics, GPL-3.0 license
+# YOLOv3 🚀 by Ultralytics, AGPL-3.0 license
 """
 Run  classification inference on images, videos, directories, globs, YouTube, webcam, streams, etc.
 

--- a/classify/train.py
+++ b/classify/train.py
@@ -1,4 +1,4 @@
-# YOLOv3 🚀 by Ultralytics, GPL-3.0 license
+# YOLOv3 🚀 by Ultralytics, AGPL-3.0 license
 """
 Train a YOLOv5 classifier model on a classification dataset
 

--- a/classify/val.py
+++ b/classify/val.py
@@ -1,4 +1,4 @@
-# YOLOv3 🚀 by Ultralytics, GPL-3.0 license
+# YOLOv3 🚀 by Ultralytics, AGPL-3.0 license
 """
 Validate a trained YOLOv5 classification model on a classification dataset
 

--- a/data/Argoverse.yaml
+++ b/data/Argoverse.yaml
@@ -1,4 +1,4 @@
-# YOLOv3 🚀 by Ultralytics, GPL-3.0 license
+# YOLOv3 🚀 by Ultralytics, AGPL-3.0 license
 # Argoverse-HD dataset (ring-front-center camera) http://www.cs.cmu.edu/~mengtial/proj/streaming/ by Argo AI
 # Example usage: python train.py --data Argoverse.yaml
 # parent

--- a/data/GlobalWheat2020.yaml
+++ b/data/GlobalWheat2020.yaml
@@ -1,4 +1,4 @@
-# YOLOv3 🚀 by Ultralytics, GPL-3.0 license
+# YOLOv3 🚀 by Ultralytics, AGPL-3.0 license
 # Global Wheat 2020 dataset http://www.global-wheat.com/ by University of Saskatchewan
 # Example usage: python train.py --data GlobalWheat2020.yaml
 # parent

--- a/data/ImageNet.yaml
+++ b/data/ImageNet.yaml
@@ -1,4 +1,4 @@
-# YOLOv3 🚀 by Ultralytics, GPL-3.0 license
+# YOLOv3 🚀 by Ultralytics, AGPL-3.0 license
 # ImageNet-1k dataset https://www.image-net.org/index.php by Stanford University
 # Simplified class names from https://github.com/anishathalye/imagenet-simple-labels
 # Example usage: python classify/train.py --data imagenet

--- a/data/SKU-110K.yaml
+++ b/data/SKU-110K.yaml
@@ -1,4 +1,4 @@
-# YOLOv3 🚀 by Ultralytics, GPL-3.0 license
+# YOLOv3 🚀 by Ultralytics, AGPL-3.0 license
 # SKU-110K retail items dataset https://github.com/eg4000/SKU110K_CVPR19 by Trax Retail
 # Example usage: python train.py --data SKU-110K.yaml
 # parent

--- a/data/VisDrone.yaml
+++ b/data/VisDrone.yaml
@@ -1,4 +1,4 @@
-# YOLOv3 🚀 by Ultralytics, GPL-3.0 license
+# YOLOv3 🚀 by Ultralytics, AGPL-3.0 license
 # VisDrone2019-DET dataset https://github.com/VisDrone/VisDrone-Dataset by Tianjin University
 # Example usage: python train.py --data VisDrone.yaml
 # parent

--- a/data/coco.yaml
+++ b/data/coco.yaml
@@ -1,4 +1,4 @@
-# YOLOv3 🚀 by Ultralytics, GPL-3.0 license
+# YOLOv3 🚀 by Ultralytics, AGPL-3.0 license
 # COCO 2017 dataset http://cocodataset.org by Microsoft
 # Example usage: python train.py --data coco.yaml
 # parent

--- a/data/coco128-seg.yaml
+++ b/data/coco128-seg.yaml
@@ -1,4 +1,4 @@
-# YOLOv3 🚀 by Ultralytics, GPL-3.0 license
+# YOLOv3 🚀 by Ultralytics, AGPL-3.0 license
 # COCO128-seg dataset https://www.kaggle.com/ultralytics/coco128 (first 128 images from COCO train2017) by Ultralytics
 # Example usage: python train.py --data coco128.yaml
 # parent

--- a/data/coco128.yaml
+++ b/data/coco128.yaml
@@ -1,4 +1,4 @@
-# YOLOv3 🚀 by Ultralytics, GPL-3.0 license
+# YOLOv3 🚀 by Ultralytics, AGPL-3.0 license
 # COCO128 dataset https://www.kaggle.com/ultralytics/coco128 (first 128 images from COCO train2017) by Ultralytics
 # Example usage: python train.py --data coco128.yaml
 # parent

--- a/data/hyps/hyp.Objects365.yaml
+++ b/data/hyps/hyp.Objects365.yaml
@@ -1,4 +1,4 @@
-# YOLOv3 🚀 by Ultralytics, GPL-3.0 license
+# YOLOv3 🚀 by Ultralytics, AGPL-3.0 license
 # Hyperparameters for Objects365 training
 # python train.py --weights yolov5m.pt --data Objects365.yaml --evolve
 # See Hyperparameter Evolution tutorial for details https://github.com/ultralytics/yolov5#tutorials

--- a/data/hyps/hyp.VOC.yaml
+++ b/data/hyps/hyp.VOC.yaml
@@ -1,4 +1,4 @@
-# YOLOv3 🚀 by Ultralytics, GPL-3.0 license
+# YOLOv3 🚀 by Ultralytics, AGPL-3.0 license
 # Hyperparameters for VOC training
 # python train.py --batch 128 --weights yolov5m6.pt --data VOC.yaml --epochs 50 --img 512 --hyp hyp.scratch-med.yaml --evolve
 # See Hyperparameter Evolution tutorial for details https://github.com/ultralytics/yolov5#tutorials

--- a/data/hyps/hyp.no-augmentation.yaml
+++ b/data/hyps/hyp.no-augmentation.yaml
@@ -1,4 +1,4 @@
-# YOLOv3 🚀 by Ultralytics, GPL-3.0 license
+# YOLOv3 🚀 by Ultralytics, AGPL-3.0 license
 # Hyperparameters when using Albumentations frameworks
 # python train.py --hyp hyp.no-augmentation.yaml
 # See https://github.com/ultralytics/yolov5/pull/3882 for YOLOv5 + Albumentations Usage examples

--- a/data/hyps/hyp.scratch-high.yaml
+++ b/data/hyps/hyp.scratch-high.yaml
@@ -1,4 +1,4 @@
-# YOLOv3 🚀 by Ultralytics, GPL-3.0 license
+# YOLOv3 🚀 by Ultralytics, AGPL-3.0 license
 # Hyperparameters for high-augmentation COCO training from scratch
 # python train.py --batch 32 --cfg yolov5m6.yaml --weights '' --data coco.yaml --img 1280 --epochs 300
 # See tutorials for hyperparameter evolution https://github.com/ultralytics/yolov5#tutorials

--- a/data/hyps/hyp.scratch-low.yaml
+++ b/data/hyps/hyp.scratch-low.yaml
@@ -1,4 +1,4 @@
-# YOLOv3 🚀 by Ultralytics, GPL-3.0 license
+# YOLOv3 🚀 by Ultralytics, AGPL-3.0 license
 # Hyperparameters for low-augmentation COCO training from scratch
 # python train.py --batch 64 --cfg yolov5n6.yaml --weights '' --data coco.yaml --img 640 --epochs 300 --linear
 # See tutorials for hyperparameter evolution https://github.com/ultralytics/yolov5#tutorials

--- a/data/hyps/hyp.scratch-med.yaml
+++ b/data/hyps/hyp.scratch-med.yaml
@@ -1,4 +1,4 @@
-# YOLOv3 🚀 by Ultralytics, GPL-3.0 license
+# YOLOv3 🚀 by Ultralytics, AGPL-3.0 license
 # Hyperparameters for medium-augmentation COCO training from scratch
 # python train.py --batch 32 --cfg yolov5m6.yaml --weights '' --data coco.yaml --img 1280 --epochs 300
 # See tutorials for hyperparameter evolution https://github.com/ultralytics/yolov5#tutorials

--- a/data/objects365.yaml
+++ b/data/objects365.yaml
@@ -1,4 +1,4 @@
-# YOLOv3 🚀 by Ultralytics, GPL-3.0 license
+# YOLOv3 🚀 by Ultralytics, AGPL-3.0 license
 # Objects365 dataset https://www.objects365.org/ by Megvii
 # Example usage: python train.py --data Objects365.yaml
 # parent

--- a/data/scripts/download_weights.sh
+++ b/data/scripts/download_weights.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# YOLOv3 🚀 by Ultralytics, GPL-3.0 license
+# YOLOv3 🚀 by Ultralytics, AGPL-3.0 license
 # Download latest models from https://github.com/ultralytics/yolov5/releases
 # Example usage: bash data/scripts/download_weights.sh
 # parent

--- a/data/scripts/get_coco.sh
+++ b/data/scripts/get_coco.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# YOLOv3 🚀 by Ultralytics, GPL-3.0 license
+# YOLOv3 🚀 by Ultralytics, AGPL-3.0 license
 # Download COCO 2017 dataset http://cocodataset.org
 # Example usage: bash data/scripts/get_coco.sh
 # parent

--- a/data/scripts/get_coco128.sh
+++ b/data/scripts/get_coco128.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# YOLOv3 🚀 by Ultralytics, GPL-3.0 license
+# YOLOv3 🚀 by Ultralytics, AGPL-3.0 license
 # Download COCO128 dataset https://www.kaggle.com/ultralytics/coco128 (first 128 images from COCO train2017)
 # Example usage: bash data/scripts/get_coco128.sh
 # parent

--- a/data/scripts/get_imagenet.sh
+++ b/data/scripts/get_imagenet.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# YOLOv3 🚀 by Ultralytics, GPL-3.0 license
+# YOLOv3 🚀 by Ultralytics, AGPL-3.0 license
 # Download ILSVRC2012 ImageNet dataset https://image-net.org
 # Example usage: bash data/scripts/get_imagenet.sh
 # parent

--- a/data/voc.yaml
+++ b/data/voc.yaml
@@ -1,4 +1,4 @@
-# YOLOv3 🚀 by Ultralytics, GPL-3.0 license
+# YOLOv3 🚀 by Ultralytics, AGPL-3.0 license
 # PASCAL VOC dataset http://host.robots.ox.ac.uk/pascal/VOC by University of Oxford
 # Example usage: python train.py --data VOC.yaml
 # parent

--- a/data/xView.yaml
+++ b/data/xView.yaml
@@ -1,4 +1,4 @@
-# YOLOv3 🚀 by Ultralytics, GPL-3.0 license
+# YOLOv3 🚀 by Ultralytics, AGPL-3.0 license
 # DIUx xView 2018 Challenge https://challenge.xviewdataset.org by U.S. National Geospatial-Intelligence Agency (NGA)
 # --------  DOWNLOAD DATA MANUALLY and jar xf val_images.zip to 'datasets/xView' before running train command!  --------
 # Example usage: python train.py --data xView.yaml

--- a/detect.py
+++ b/detect.py
@@ -1,4 +1,4 @@
-# YOLOv3 🚀 by Ultralytics, GPL-3.0 license
+# YOLOv3 🚀 by Ultralytics, AGPL-3.0 license
 """
 Run YOLOv3 detection inference on images, videos, directories, globs, YouTube, webcam, streams, etc.
 

--- a/export.py
+++ b/export.py
@@ -1,4 +1,4 @@
-# YOLOv3 🚀 by Ultralytics, GPL-3.0 license
+# YOLOv3 🚀 by Ultralytics, AGPL-3.0 license
 """
 Export a YOLOv3 PyTorch model to other formats. TensorFlow exports authored by https://github.com/zldrobit
 

--- a/hubconf.py
+++ b/hubconf.py
@@ -1,4 +1,4 @@
-# YOLOv3 🚀 by Ultralytics, GPL-3.0 license
+# YOLOv3 🚀 by Ultralytics, AGPL-3.0 license
 """
 PyTorch Hub models https://pytorch.org/hub/ultralytics_yolov5
 

--- a/models/common.py
+++ b/models/common.py
@@ -1,4 +1,4 @@
-# YOLOv3 🚀 by Ultralytics, GPL-3.0 license
+# YOLOv3 🚀 by Ultralytics, AGPL-3.0 license
 """
 Common modules
 """

--- a/models/experimental.py
+++ b/models/experimental.py
@@ -1,4 +1,4 @@
-# YOLOv3 🚀 by Ultralytics, GPL-3.0 license
+# YOLOv3 🚀 by Ultralytics, AGPL-3.0 license
 """
 Experimental modules
 """

--- a/models/hub/anchors.yaml
+++ b/models/hub/anchors.yaml
@@ -1,4 +1,4 @@
-# YOLOv3 🚀 by Ultralytics, GPL-3.0 license
+# YOLOv3 🚀 by Ultralytics, AGPL-3.0 license
 # Default anchors for COCO data
 
 

--- a/models/hub/yolov5-bifpn.yaml
+++ b/models/hub/yolov5-bifpn.yaml
@@ -1,4 +1,4 @@
-# YOLOv3 🚀 by Ultralytics, GPL-3.0 license
+# YOLOv3 🚀 by Ultralytics, AGPL-3.0 license
 
 # Parameters
 nc: 80  # number of classes

--- a/models/hub/yolov5-fpn.yaml
+++ b/models/hub/yolov5-fpn.yaml
@@ -1,4 +1,4 @@
-# YOLOv3 🚀 by Ultralytics, GPL-3.0 license
+# YOLOv3 🚀 by Ultralytics, AGPL-3.0 license
 
 # Parameters
 nc: 80  # number of classes

--- a/models/hub/yolov5-p2.yaml
+++ b/models/hub/yolov5-p2.yaml
@@ -1,4 +1,4 @@
-# YOLOv3 🚀 by Ultralytics, GPL-3.0 license
+# YOLOv3 🚀 by Ultralytics, AGPL-3.0 license
 
 # Parameters
 nc: 80  # number of classes

--- a/models/hub/yolov5-p34.yaml
+++ b/models/hub/yolov5-p34.yaml
@@ -1,4 +1,4 @@
-# YOLOv3 🚀 by Ultralytics, GPL-3.0 license
+# YOLOv3 🚀 by Ultralytics, AGPL-3.0 license
 
 # Parameters
 nc: 80  # number of classes

--- a/models/hub/yolov5-p6.yaml
+++ b/models/hub/yolov5-p6.yaml
@@ -1,4 +1,4 @@
-# YOLOv3 🚀 by Ultralytics, GPL-3.0 license
+# YOLOv3 🚀 by Ultralytics, AGPL-3.0 license
 
 # Parameters
 nc: 80  # number of classes

--- a/models/hub/yolov5-p7.yaml
+++ b/models/hub/yolov5-p7.yaml
@@ -1,4 +1,4 @@
-# YOLOv3 🚀 by Ultralytics, GPL-3.0 license
+# YOLOv3 🚀 by Ultralytics, AGPL-3.0 license
 
 # Parameters
 nc: 80  # number of classes

--- a/models/hub/yolov5-panet.yaml
+++ b/models/hub/yolov5-panet.yaml
@@ -1,4 +1,4 @@
-# YOLOv3 🚀 by Ultralytics, GPL-3.0 license
+# YOLOv3 🚀 by Ultralytics, AGPL-3.0 license
 
 # Parameters
 nc: 80  # number of classes

--- a/models/hub/yolov5l6.yaml
+++ b/models/hub/yolov5l6.yaml
@@ -1,4 +1,4 @@
-# YOLOv3 🚀 by Ultralytics, GPL-3.0 license
+# YOLOv3 🚀 by Ultralytics, AGPL-3.0 license
 
 # Parameters
 nc: 80  # number of classes

--- a/models/hub/yolov5m6.yaml
+++ b/models/hub/yolov5m6.yaml
@@ -1,4 +1,4 @@
-# YOLOv3 🚀 by Ultralytics, GPL-3.0 license
+# YOLOv3 🚀 by Ultralytics, AGPL-3.0 license
 
 # Parameters
 nc: 80  # number of classes

--- a/models/hub/yolov5n6.yaml
+++ b/models/hub/yolov5n6.yaml
@@ -1,4 +1,4 @@
-# YOLOv3 🚀 by Ultralytics, GPL-3.0 license
+# YOLOv3 🚀 by Ultralytics, AGPL-3.0 license
 
 # Parameters
 nc: 80  # number of classes

--- a/models/hub/yolov5s-LeakyReLU.yaml
+++ b/models/hub/yolov5s-LeakyReLU.yaml
@@ -1,4 +1,4 @@
-# YOLOv3 🚀 by Ultralytics, GPL-3.0 license
+# YOLOv3 🚀 by Ultralytics, AGPL-3.0 license
 
 # Parameters
 nc: 80  # number of classes

--- a/models/hub/yolov5s-ghost.yaml
+++ b/models/hub/yolov5s-ghost.yaml
@@ -1,4 +1,4 @@
-# YOLOv3 🚀 by Ultralytics, GPL-3.0 license
+# YOLOv3 🚀 by Ultralytics, AGPL-3.0 license
 
 # Parameters
 nc: 80  # number of classes

--- a/models/hub/yolov5s-transformer.yaml
+++ b/models/hub/yolov5s-transformer.yaml
@@ -1,4 +1,4 @@
-# YOLOv3 🚀 by Ultralytics, GPL-3.0 license
+# YOLOv3 🚀 by Ultralytics, AGPL-3.0 license
 
 # Parameters
 nc: 80  # number of classes

--- a/models/hub/yolov5s6.yaml
+++ b/models/hub/yolov5s6.yaml
@@ -1,4 +1,4 @@
-# YOLOv3 🚀 by Ultralytics, GPL-3.0 license
+# YOLOv3 🚀 by Ultralytics, AGPL-3.0 license
 
 # Parameters
 nc: 80  # number of classes

--- a/models/hub/yolov5x6.yaml
+++ b/models/hub/yolov5x6.yaml
@@ -1,4 +1,4 @@
-# YOLOv3 🚀 by Ultralytics, GPL-3.0 license
+# YOLOv3 🚀 by Ultralytics, AGPL-3.0 license
 
 # Parameters
 nc: 80  # number of classes

--- a/models/segment/yolov5l-seg.yaml
+++ b/models/segment/yolov5l-seg.yaml
@@ -1,4 +1,4 @@
-# YOLOv3 🚀 by Ultralytics, GPL-3.0 license
+# YOLOv3 🚀 by Ultralytics, AGPL-3.0 license
 
 # Parameters
 nc: 80  # number of classes

--- a/models/segment/yolov5m-seg.yaml
+++ b/models/segment/yolov5m-seg.yaml
@@ -1,4 +1,4 @@
-# YOLOv3 🚀 by Ultralytics, GPL-3.0 license
+# YOLOv3 🚀 by Ultralytics, AGPL-3.0 license
 
 # Parameters
 nc: 80  # number of classes

--- a/models/segment/yolov5n-seg.yaml
+++ b/models/segment/yolov5n-seg.yaml
@@ -1,4 +1,4 @@
-# YOLOv3 🚀 by Ultralytics, GPL-3.0 license
+# YOLOv3 🚀 by Ultralytics, AGPL-3.0 license
 
 # Parameters
 nc: 80  # number of classes

--- a/models/segment/yolov5s-seg.yaml
+++ b/models/segment/yolov5s-seg.yaml
@@ -1,4 +1,4 @@
-# YOLOv3 🚀 by Ultralytics, GPL-3.0 license
+# YOLOv3 🚀 by Ultralytics, AGPL-3.0 license
 
 # Parameters
 nc: 80  # number of classes

--- a/models/segment/yolov5x-seg.yaml
+++ b/models/segment/yolov5x-seg.yaml
@@ -1,4 +1,4 @@
-# YOLOv3 🚀 by Ultralytics, GPL-3.0 license
+# YOLOv3 🚀 by Ultralytics, AGPL-3.0 license
 
 # Parameters
 nc: 80  # number of classes

--- a/models/tf.py
+++ b/models/tf.py
@@ -1,4 +1,4 @@
-# YOLOv3 🚀 by Ultralytics, GPL-3.0 license
+# YOLOv3 🚀 by Ultralytics, AGPL-3.0 license
 """
 TensorFlow, Keras and TFLite versions of YOLOv3
 Authored by https://github.com/zldrobit in PR https://github.com/ultralytics/yolov5/pull/1127

--- a/models/yolo.py
+++ b/models/yolo.py
@@ -1,4 +1,4 @@
-# YOLOv3 🚀 by Ultralytics, GPL-3.0 license
+# YOLOv3 🚀 by Ultralytics, AGPL-3.0 license
 """
 YOLO-specific modules
 

--- a/models/yolov3-spp.yaml
+++ b/models/yolov3-spp.yaml
@@ -1,4 +1,4 @@
-# YOLOv3 🚀 by Ultralytics, GPL-3.0 license
+# YOLOv3 🚀 by Ultralytics, AGPL-3.0 license
 
 # Parameters
 nc: 80  # number of classes

--- a/models/yolov3-tiny.yaml
+++ b/models/yolov3-tiny.yaml
@@ -1,4 +1,4 @@
-# YOLOv3 🚀 by Ultralytics, GPL-3.0 license
+# YOLOv3 🚀 by Ultralytics, AGPL-3.0 license
 
 # Parameters
 nc: 80  # number of classes

--- a/models/yolov3.yaml
+++ b/models/yolov3.yaml
@@ -1,4 +1,4 @@
-# YOLOv3 🚀 by Ultralytics, GPL-3.0 license
+# YOLOv3 🚀 by Ultralytics, AGPL-3.0 license
 
 # Parameters
 nc: 80  # number of classes

--- a/models/yolov5l.yaml
+++ b/models/yolov5l.yaml
@@ -1,4 +1,4 @@
-# YOLOv3 🚀 by Ultralytics, GPL-3.0 license
+# YOLOv3 🚀 by Ultralytics, AGPL-3.0 license
 
 # Parameters
 nc: 80  # number of classes

--- a/models/yolov5m.yaml
+++ b/models/yolov5m.yaml
@@ -1,4 +1,4 @@
-# YOLOv3 🚀 by Ultralytics, GPL-3.0 license
+# YOLOv3 🚀 by Ultralytics, AGPL-3.0 license
 
 # Parameters
 nc: 80  # number of classes

--- a/models/yolov5n.yaml
+++ b/models/yolov5n.yaml
@@ -1,4 +1,4 @@
-# YOLOv3 🚀 by Ultralytics, GPL-3.0 license
+# YOLOv3 🚀 by Ultralytics, AGPL-3.0 license
 
 # Parameters
 nc: 80  # number of classes

--- a/models/yolov5s.yaml
+++ b/models/yolov5s.yaml
@@ -1,4 +1,4 @@
-# YOLOv3 🚀 by Ultralytics, GPL-3.0 license
+# YOLOv3 🚀 by Ultralytics, AGPL-3.0 license
 
 # Parameters
 nc: 80  # number of classes

--- a/models/yolov5x.yaml
+++ b/models/yolov5x.yaml
@@ -1,4 +1,4 @@
-# YOLOv3 🚀 by Ultralytics, GPL-3.0 license
+# YOLOv3 🚀 by Ultralytics, AGPL-3.0 license
 
 # Parameters
 nc: 80  # number of classes

--- a/segment/predict.py
+++ b/segment/predict.py
@@ -1,4 +1,4 @@
-# YOLOv3 🚀 by Ultralytics, GPL-3.0 license
+# YOLOv3 🚀 by Ultralytics, AGPL-3.0 license
 """
 Run  segmentation inference on images, videos, directories, streams, etc.
 

--- a/segment/train.py
+++ b/segment/train.py
@@ -1,4 +1,4 @@
-# YOLOv3 🚀 by Ultralytics, GPL-3.0 license
+# YOLOv3 🚀 by Ultralytics, AGPL-3.0 license
 """
 Train a  segment model on a segment dataset
 Models and datasets download automatically from the latest  release.

--- a/segment/val.py
+++ b/segment/val.py
@@ -1,4 +1,4 @@
-# YOLOv3 🚀 by Ultralytics, GPL-3.0 license
+# YOLOv3 🚀 by Ultralytics, AGPL-3.0 license
 """
 Validate a trained  segment model on a segment dataset
 

--- a/train.py
+++ b/train.py
@@ -1,4 +1,4 @@
-# YOLOv3 🚀 by Ultralytics, GPL-3.0 license
+# YOLOv3 🚀 by Ultralytics, AGPL-3.0 license
 """
 Train a YOLOv3 model on a custom dataset.
 Models and datasets download automatically from the latest YOLOv3 release.

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,4 +1,4 @@
-# YOLOv3 🚀 by Ultralytics, GPL-3.0 license
+# YOLOv3 🚀 by Ultralytics, AGPL-3.0 license
 """
 utils/initialization
 """

--- a/utils/activations.py
+++ b/utils/activations.py
@@ -1,4 +1,4 @@
-# YOLOv3 🚀 by Ultralytics, GPL-3.0 license
+# YOLOv3 🚀 by Ultralytics, AGPL-3.0 license
 """
 Activation functions
 """

--- a/utils/augmentations.py
+++ b/utils/augmentations.py
@@ -1,4 +1,4 @@
-# YOLOv3 🚀 by Ultralytics, GPL-3.0 license
+# YOLOv3 🚀 by Ultralytics, AGPL-3.0 license
 """
 Image augmentation functions
 """

--- a/utils/autoanchor.py
+++ b/utils/autoanchor.py
@@ -1,4 +1,4 @@
-# YOLOv3 🚀 by Ultralytics, GPL-3.0 license
+# YOLOv3 🚀 by Ultralytics, AGPL-3.0 license
 """
 AutoAnchor utils
 """

--- a/utils/autobatch.py
+++ b/utils/autobatch.py
@@ -1,4 +1,4 @@
-# YOLOv3 🚀 by Ultralytics, GPL-3.0 license
+# YOLOv3 🚀 by Ultralytics, AGPL-3.0 license
 """
 Auto-batch utils
 """

--- a/utils/callbacks.py
+++ b/utils/callbacks.py
@@ -1,4 +1,4 @@
-# YOLOv3 🚀 by Ultralytics, GPL-3.0 license
+# YOLOv3 🚀 by Ultralytics, AGPL-3.0 license
 """
 Callback utils
 """

--- a/utils/dataloaders.py
+++ b/utils/dataloaders.py
@@ -1,4 +1,4 @@
-# YOLOv3 🚀 by Ultralytics, GPL-3.0 license
+# YOLOv3 🚀 by Ultralytics, AGPL-3.0 license
 """
 Dataloaders and dataset utils
 """

--- a/utils/docker/Dockerfile
+++ b/utils/docker/Dockerfile
@@ -1,4 +1,4 @@
-# YOLOv3 🚀 by Ultralytics, GPL-3.0 license
+# YOLOv3 🚀 by Ultralytics, AGPL-3.0 license
 # Builds ultralytics/yolov5:latest image on DockerHub https://hub.docker.com/r/ultralytics/yolov3
 # Image is CUDA-optimized for YOLOv5 single/multi-GPU training and inference
 

--- a/utils/docker/Dockerfile-arm64
+++ b/utils/docker/Dockerfile-arm64
@@ -1,4 +1,4 @@
-# YOLOv3 🚀 by Ultralytics, GPL-3.0 license
+# YOLOv3 🚀 by Ultralytics, AGPL-3.0 license
 # Builds ultralytics/yolov5:latest-arm64 image on DockerHub https://hub.docker.com/r/ultralytics/yolov3
 # Image is aarch64-compatible for Apple M1 and other ARM architectures i.e. Jetson Nano and Raspberry Pi
 

--- a/utils/docker/Dockerfile-cpu
+++ b/utils/docker/Dockerfile-cpu
@@ -1,4 +1,4 @@
-# YOLOv3 🚀 by Ultralytics, GPL-3.0 license
+# YOLOv3 🚀 by Ultralytics, AGPL-3.0 license
 # Builds ultralytics/yolov5:latest-cpu image on DockerHub https://hub.docker.com/r/ultralytics/yolov3
 # Image is CPU-optimized for ONNX, OpenVINO and PyTorch YOLOv5 deployments
 

--- a/utils/downloads.py
+++ b/utils/downloads.py
@@ -1,4 +1,4 @@
-# YOLOv3 🚀 by Ultralytics, GPL-3.0 license
+# YOLOv3 🚀 by Ultralytics, AGPL-3.0 license
 """
 Download utils
 """

--- a/utils/flask_rest_api/example_request.py
+++ b/utils/flask_rest_api/example_request.py
@@ -1,4 +1,4 @@
-# YOLOv3 🚀 by Ultralytics, GPL-3.0 license
+# YOLOv3 🚀 by Ultralytics, AGPL-3.0 license
 """
 Perform test request
 """

--- a/utils/flask_rest_api/restapi.py
+++ b/utils/flask_rest_api/restapi.py
@@ -1,4 +1,4 @@
-# YOLOv3 🚀 by Ultralytics, GPL-3.0 license
+# YOLOv3 🚀 by Ultralytics, AGPL-3.0 license
 """
 Run a Flask REST API exposing one or more YOLOv5s models
 """

--- a/utils/general.py
+++ b/utils/general.py
@@ -1,4 +1,4 @@
-# YOLOv3 🚀 by Ultralytics, GPL-3.0 license
+# YOLOv3 🚀 by Ultralytics, AGPL-3.0 license
 """
 General utils
 """

--- a/utils/loggers/__init__.py
+++ b/utils/loggers/__init__.py
@@ -1,4 +1,4 @@
-# YOLOv3 🚀 by Ultralytics, GPL-3.0 license
+# YOLOv3 🚀 by Ultralytics, AGPL-3.0 license
 """
 Logging utils
 """

--- a/utils/loggers/wandb/wandb_utils.py
+++ b/utils/loggers/wandb/wandb_utils.py
@@ -1,4 +1,4 @@
-# YOLOv3 🚀 by Ultralytics, GPL-3.0 license
+# YOLOv3 🚀 by Ultralytics, AGPL-3.0 license
 
 # WARNING ⚠️ wandb is deprecated and will be removed in future release.
 # See supported integrations at https://github.com/ultralytics/yolov5#integrations

--- a/utils/loss.py
+++ b/utils/loss.py
@@ -1,4 +1,4 @@
-# YOLOv3 🚀 by Ultralytics, GPL-3.0 license
+# YOLOv3 🚀 by Ultralytics, AGPL-3.0 license
 """
 Loss functions
 """

--- a/utils/metrics.py
+++ b/utils/metrics.py
@@ -1,4 +1,4 @@
-# YOLOv3 🚀 by Ultralytics, GPL-3.0 license
+# YOLOv3 🚀 by Ultralytics, AGPL-3.0 license
 """
 Model validation metrics
 """

--- a/utils/plots.py
+++ b/utils/plots.py
@@ -1,4 +1,4 @@
-# YOLOv3 🚀 by Ultralytics, GPL-3.0 license
+# YOLOv3 🚀 by Ultralytics, AGPL-3.0 license
 """
 Plotting utils
 """

--- a/utils/segment/augmentations.py
+++ b/utils/segment/augmentations.py
@@ -1,4 +1,4 @@
-# YOLOv3 🚀 by Ultralytics, GPL-3.0 license
+# YOLOv3 🚀 by Ultralytics, AGPL-3.0 license
 """
 Image augmentation functions
 """

--- a/utils/segment/dataloaders.py
+++ b/utils/segment/dataloaders.py
@@ -1,4 +1,4 @@
-# YOLOv3 🚀 by Ultralytics, GPL-3.0 license
+# YOLOv3 🚀 by Ultralytics, AGPL-3.0 license
 """
 Dataloaders
 """

--- a/utils/segment/metrics.py
+++ b/utils/segment/metrics.py
@@ -1,4 +1,4 @@
-# YOLOv3 🚀 by Ultralytics, GPL-3.0 license
+# YOLOv3 🚀 by Ultralytics, AGPL-3.0 license
 """
 Model validation metrics
 """

--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -1,4 +1,4 @@
-# YOLOv3 🚀 by Ultralytics, GPL-3.0 license
+# YOLOv3 🚀 by Ultralytics, AGPL-3.0 license
 """
 PyTorch utils
 """

--- a/utils/triton.py
+++ b/utils/triton.py
@@ -1,4 +1,4 @@
-# YOLOv3 🚀 by Ultralytics, GPL-3.0 license
+# YOLOv3 🚀 by Ultralytics, AGPL-3.0 license
 """ Utils to interact with the Triton Inference Server
 """
 

--- a/val.py
+++ b/val.py
@@ -1,4 +1,4 @@
-# YOLOv3 🚀 by Ultralytics, GPL-3.0 license
+# YOLOv3 🚀 by Ultralytics, AGPL-3.0 license
 """
 Validate a trained YOLOv3 detection model on a detection dataset
 


### PR DESCRIPTION
This pull request updates the license of the YOLOv3 project from GNU General Public License v3.0 (GPL-3.0) to GNU Affero General Public License v3.0 (AGPL-3.0).

We at Ultralytics have decided to make this change in order to better protect our intellectual property and ensure that any modifications made to the YOLOv3 source code will be shared back with the community when used over a network.

AGPL-3.0 is very similar to GPL-3.0, but with an additional clause to address the use of software over a network. This change ensures that if someone modifies YOLOv3 and provides it as a service over a network (e.g., through a web application or API), they must also make the source code of their modified version available to users of the service.

This update includes the following changes:

- Replace the LICENSE file with the AGPL-3.0 license text 
- Update the license reference in the README.md file 
- Update the license headers in source code files

We believe that this change will promote a more collaborative environment and help drive further innovation within the YOLOv3 community.


