### PR TITLE
Standardize license headers in TOML/YAML files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,4 +1,4 @@
-# Ultralytics YOLOv3 🚀, AGPL-3.0 license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 name: 🐛 Bug Report
 # title: " "

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-# Ultralytics YOLOv3 🚀, AGPL-3.0 license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 blank_issues_enabled: true
 contact_links:

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,4 +1,4 @@
-# Ultralytics YOLOv3 🚀, AGPL-3.0 license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 name: 🚀 Feature Request
 description: Suggest a YOLOv3 idea

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,4 +1,4 @@
-# Ultralytics YOLOv3 🚀, AGPL-3.0 license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 name: ❓ Question
 description: Ask a YOLOv3 question

--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -1,4 +1,5 @@
-# Ultralytics YOLOv3 🚀, AGPL-3.0 license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 # YOLOv3 Continuous Integration (CI) GitHub Actions tests
 
 name: YOLOv3 CI

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,4 +1,5 @@
-# Ultralytics YOLO 🚀, AGPL-3.0 license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 # Ultralytics Contributor License Agreement (CLA) action https://docs.ultralytics.com/help/CLA
 # This workflow automatically requests Pull Requests (PR) authors to sign the Ultralytics CLA before PRs can be merged
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,4 +1,5 @@
-# Ultralytics YOLOv3 🚀, AGPL-3.0 license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 # Builds ultralytics/yolov3:latest images on DockerHub https://hub.docker.com/r/ultralytics/yolov3
 
 name: Publish Docker Images

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,4 +1,5 @@
-# Ultralytics 🚀 - AGPL-3.0 License https://ultralytics.com/license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 # Ultralytics Actions https://github.com/ultralytics/actions
 # This workflow automatically formats code and documentation in PRs to official Ultralytics standards
 

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -1,4 +1,5 @@
-# Ultralytics YOLOv3 🚀, AGPL-3.0 license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 # Continuous Integration (CI) GitHub Actions tests broken link checker using https://github.com/lycheeverse/lychee
 # Ignores the following status codes to reduce false positives:
 #   - 403(OpenVINO, 'forbidden')

--- a/.github/workflows/merge-main-into-prs.yml
+++ b/.github/workflows/merge-main-into-prs.yml
@@ -1,4 +1,5 @@
-# Ultralytics YOLO 🚀, AGPL-3.0 license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 # Automatically merges repository 'main' branch into all open PRs to keep them up-to-date
 # Action runs on updates to main branch so when one PR merges to main all others update
 

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,4 +1,4 @@
-# Ultralytics YOLOv3 🚀, AGPL-3.0 license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 name: Close stale issues
 on:

--- a/data/Argoverse.yaml
+++ b/data/Argoverse.yaml
@@ -1,4 +1,5 @@
-# Ultralytics YOLOv3 🚀, AGPL-3.0 license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 # Argoverse-HD dataset (ring-front-center camera) http://www.cs.cmu.edu/~mengtial/proj/streaming/ by Argo AI
 # Example usage: python train.py --data Argoverse.yaml
 # parent

--- a/data/GlobalWheat2020.yaml
+++ b/data/GlobalWheat2020.yaml
@@ -1,4 +1,5 @@
-# Ultralytics YOLOv3 🚀, AGPL-3.0 license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 # Global Wheat 2020 dataset http://www.global-wheat.com/ by University of Saskatchewan
 # Example usage: python train.py --data GlobalWheat2020.yaml
 # parent

--- a/data/ImageNet.yaml
+++ b/data/ImageNet.yaml
@@ -1,4 +1,5 @@
-# Ultralytics YOLOv3 🚀, AGPL-3.0 license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 # ImageNet-1k dataset https://www.image-net.org/index.php by Stanford University
 # Simplified class names from https://github.com/anishathalye/imagenet-simple-labels
 # Example usage: python classify/train.py --data imagenet

--- a/data/SKU-110K.yaml
+++ b/data/SKU-110K.yaml
@@ -1,4 +1,5 @@
-# Ultralytics YOLOv3 🚀, AGPL-3.0 license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 # SKU-110K retail items dataset https://github.com/eg4000/SKU110K_CVPR19 by Trax Retail
 # Example usage: python train.py --data SKU-110K.yaml
 # parent

--- a/data/VisDrone.yaml
+++ b/data/VisDrone.yaml
@@ -1,4 +1,5 @@
-# Ultralytics YOLOv3 🚀, AGPL-3.0 license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 # VisDrone2019-DET dataset https://github.com/VisDrone/VisDrone-Dataset by Tianjin University
 # Example usage: python train.py --data VisDrone.yaml
 # parent

--- a/data/coco.yaml
+++ b/data/coco.yaml
@@ -1,4 +1,5 @@
-# Ultralytics YOLOv3 🚀, AGPL-3.0 license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 # COCO 2017 dataset http://cocodataset.org by Microsoft
 # Example usage: python train.py --data coco.yaml
 # parent

--- a/data/coco128-seg.yaml
+++ b/data/coco128-seg.yaml
@@ -1,4 +1,5 @@
-# Ultralytics YOLOv3 🚀, AGPL-3.0 license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 # COCO128-seg dataset https://www.kaggle.com/datasets/ultralytics/coco128 (first 128 images from COCO train2017) by Ultralytics
 # Example usage: python train.py --data coco128.yaml
 # parent

--- a/data/coco128.yaml
+++ b/data/coco128.yaml
@@ -1,4 +1,5 @@
-# Ultralytics YOLOv3 🚀, AGPL-3.0 license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 # COCO128 dataset https://www.kaggle.com/datasets/ultralytics/coco128 (first 128 images from COCO train2017) by Ultralytics
 # Example usage: python train.py --data coco128.yaml
 # parent

--- a/data/hyps/hyp.Objects365.yaml
+++ b/data/hyps/hyp.Objects365.yaml
@@ -1,4 +1,5 @@
-# Ultralytics YOLOv3 🚀, AGPL-3.0 license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 # Hyperparameters for Objects365 training
 # python train.py --weights yolov5m.pt --data Objects365.yaml --evolve
 # See Hyperparameter Evolution tutorial for details https://github.com/ultralytics/yolov5#tutorials

--- a/data/hyps/hyp.VOC.yaml
+++ b/data/hyps/hyp.VOC.yaml
@@ -1,4 +1,5 @@
-# Ultralytics YOLOv3 🚀, AGPL-3.0 license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 # Hyperparameters for VOC training
 # python train.py --batch 128 --weights yolov5m6.pt --data VOC.yaml --epochs 50 --img 512 --hyp hyp.scratch-med.yaml --evolve
 # See Hyperparameter Evolution tutorial for details https://github.com/ultralytics/yolov5#tutorials

--- a/data/hyps/hyp.no-augmentation.yaml
+++ b/data/hyps/hyp.no-augmentation.yaml
@@ -1,4 +1,5 @@
-# Ultralytics YOLOv3 🚀, AGPL-3.0 license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 # Hyperparameters when using Albumentations frameworks
 # python train.py --hyp hyp.no-augmentation.yaml
 # See https://github.com/ultralytics/yolov5/pull/3882 for YOLOv3 + Albumentations Usage examples

--- a/data/hyps/hyp.scratch-high.yaml
+++ b/data/hyps/hyp.scratch-high.yaml
@@ -1,4 +1,5 @@
-# Ultralytics YOLOv3 🚀, AGPL-3.0 license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 # Hyperparameters for high-augmentation COCO training from scratch
 # python train.py --batch 32 --cfg yolov5m6.yaml --weights '' --data coco.yaml --img 1280 --epochs 300
 # See tutorials for hyperparameter evolution https://github.com/ultralytics/yolov5#tutorials

--- a/data/hyps/hyp.scratch-low.yaml
+++ b/data/hyps/hyp.scratch-low.yaml
@@ -1,4 +1,5 @@
-# Ultralytics YOLOv3 🚀, AGPL-3.0 license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 # Hyperparameters for low-augmentation COCO training from scratch
 # python train.py --batch 64 --cfg yolov5n6.yaml --weights '' --data coco.yaml --img 640 --epochs 300 --linear
 # See tutorials for hyperparameter evolution https://github.com/ultralytics/yolov5#tutorials

--- a/data/hyps/hyp.scratch-med.yaml
+++ b/data/hyps/hyp.scratch-med.yaml
@@ -1,4 +1,5 @@
-# Ultralytics YOLOv3 🚀, AGPL-3.0 license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 # Hyperparameters for medium-augmentation COCO training from scratch
 # python train.py --batch 32 --cfg yolov5m6.yaml --weights '' --data coco.yaml --img 1280 --epochs 300
 # See tutorials for hyperparameter evolution https://github.com/ultralytics/yolov5#tutorials

--- a/data/objects365.yaml
+++ b/data/objects365.yaml
@@ -1,4 +1,5 @@
-# Ultralytics YOLOv3 🚀, AGPL-3.0 license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 # Objects365 dataset https://www.objects365.org/ by Megvii
 # Example usage: python train.py --data Objects365.yaml
 # parent

--- a/data/voc.yaml
+++ b/data/voc.yaml
@@ -1,4 +1,5 @@
-# Ultralytics YOLOv3 🚀, AGPL-3.0 license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 # PASCAL VOC dataset http://host.robots.ox.ac.uk/pascal/VOC by University of Oxford
 # Example usage: python train.py --data VOC.yaml
 # parent

--- a/data/xView.yaml
+++ b/data/xView.yaml
@@ -1,4 +1,5 @@
-# Ultralytics YOLOv3 🚀, AGPL-3.0 license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 # DIUx xView 2018 Challenge https://challenge.xviewdataset.org by U.S. National Geospatial-Intelligence Agency (NGA)
 # --------  DOWNLOAD DATA MANUALLY and jar xf val_images.zip to 'datasets/xView' before running train command!  --------
 # Example usage: python train.py --data xView.yaml

--- a/models/hub/anchors.yaml
+++ b/models/hub/anchors.yaml
@@ -1,4 +1,5 @@
-# Ultralytics YOLOv3 🚀, AGPL-3.0 license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 # Default anchors for COCO data
 
 # P5 -------------------------------------------------------------------------------------------------------------------

--- a/models/hub/yolov5-bifpn.yaml
+++ b/models/hub/yolov5-bifpn.yaml
@@ -1,4 +1,4 @@
-# Ultralytics YOLOv3 🚀, AGPL-3.0 license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 # Parameters
 nc: 80 # number of classes

--- a/models/hub/yolov5-fpn.yaml
+++ b/models/hub/yolov5-fpn.yaml
@@ -1,4 +1,4 @@
-# Ultralytics YOLOv3 🚀, AGPL-3.0 license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 # Parameters
 nc: 80 # number of classes

--- a/models/hub/yolov5-p2.yaml
+++ b/models/hub/yolov5-p2.yaml
@@ -1,4 +1,4 @@
-# Ultralytics YOLOv3 🚀, AGPL-3.0 license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 # Parameters
 nc: 80 # number of classes

--- a/models/hub/yolov5-p34.yaml
+++ b/models/hub/yolov5-p34.yaml
@@ -1,4 +1,4 @@
-# Ultralytics YOLOv3 🚀, AGPL-3.0 license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 # Parameters
 nc: 80 # number of classes

--- a/models/hub/yolov5-p6.yaml
+++ b/models/hub/yolov5-p6.yaml
@@ -1,4 +1,4 @@
-# Ultralytics YOLOv3 🚀, AGPL-3.0 license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 # Parameters
 nc: 80 # number of classes

--- a/models/hub/yolov5-p7.yaml
+++ b/models/hub/yolov5-p7.yaml
@@ -1,4 +1,4 @@
-# Ultralytics YOLOv3 🚀, AGPL-3.0 license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 # Parameters
 nc: 80 # number of classes

--- a/models/hub/yolov5-panet.yaml
+++ b/models/hub/yolov5-panet.yaml
@@ -1,4 +1,4 @@
-# Ultralytics YOLOv3 🚀, AGPL-3.0 license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 # Parameters
 nc: 80 # number of classes

--- a/models/hub/yolov5l6.yaml
+++ b/models/hub/yolov5l6.yaml
@@ -1,4 +1,4 @@
-# Ultralytics YOLOv3 🚀, AGPL-3.0 license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 # Parameters
 nc: 80 # number of classes

--- a/models/hub/yolov5m6.yaml
+++ b/models/hub/yolov5m6.yaml
@@ -1,4 +1,4 @@
-# Ultralytics YOLOv3 🚀, AGPL-3.0 license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 # Parameters
 nc: 80 # number of classes

--- a/models/hub/yolov5n6.yaml
+++ b/models/hub/yolov5n6.yaml
@@ -1,4 +1,4 @@
-# Ultralytics YOLOv3 🚀, AGPL-3.0 license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 # Parameters
 nc: 80 # number of classes

--- a/models/hub/yolov5s-LeakyReLU.yaml
+++ b/models/hub/yolov5s-LeakyReLU.yaml
@@ -1,4 +1,4 @@
-# Ultralytics YOLOv3 🚀, AGPL-3.0 license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 # Parameters
 nc: 80 # number of classes

--- a/models/hub/yolov5s-ghost.yaml
+++ b/models/hub/yolov5s-ghost.yaml
@@ -1,4 +1,4 @@
-# Ultralytics YOLOv3 🚀, AGPL-3.0 license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 # Parameters
 nc: 80 # number of classes

--- a/models/hub/yolov5s-transformer.yaml
+++ b/models/hub/yolov5s-transformer.yaml
@@ -1,4 +1,4 @@
-# Ultralytics YOLOv3 🚀, AGPL-3.0 license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 # Parameters
 nc: 80 # number of classes

--- a/models/hub/yolov5s6.yaml
+++ b/models/hub/yolov5s6.yaml
@@ -1,4 +1,4 @@
-# Ultralytics YOLOv3 🚀, AGPL-3.0 license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 # Parameters
 nc: 80 # number of classes

--- a/models/hub/yolov5x6.yaml
+++ b/models/hub/yolov5x6.yaml
@@ -1,4 +1,4 @@
-# Ultralytics YOLOv3 🚀, AGPL-3.0 license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 # Parameters
 nc: 80 # number of classes

--- a/models/segment/yolov5l-seg.yaml
+++ b/models/segment/yolov5l-seg.yaml
@@ -1,4 +1,4 @@
-# Ultralytics YOLOv3 🚀, AGPL-3.0 license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 # Parameters
 nc: 80 # number of classes

--- a/models/segment/yolov5m-seg.yaml
+++ b/models/segment/yolov5m-seg.yaml
@@ -1,4 +1,4 @@
-# Ultralytics YOLOv3 🚀, AGPL-3.0 license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 # Parameters
 nc: 80 # number of classes

--- a/models/segment/yolov5n-seg.yaml
+++ b/models/segment/yolov5n-seg.yaml
@@ -1,4 +1,4 @@
-# Ultralytics YOLOv3 🚀, AGPL-3.0 license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 # Parameters
 nc: 80 # number of classes

--- a/models/segment/yolov5s-seg.yaml
+++ b/models/segment/yolov5s-seg.yaml
@@ -1,4 +1,4 @@
-# Ultralytics YOLOv3 🚀, AGPL-3.0 license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 # Parameters
 nc: 80 # number of classes

--- a/models/segment/yolov5x-seg.yaml
+++ b/models/segment/yolov5x-seg.yaml
@@ -1,4 +1,4 @@
-# Ultralytics YOLOv3 🚀, AGPL-3.0 license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 # Parameters
 nc: 80 # number of classes

--- a/models/yolov3-spp.yaml
+++ b/models/yolov3-spp.yaml
@@ -1,4 +1,4 @@
-# Ultralytics YOLOv3 🚀, AGPL-3.0 license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 # Parameters
 nc: 80 # number of classes

--- a/models/yolov3-tiny.yaml
+++ b/models/yolov3-tiny.yaml
@@ -1,4 +1,4 @@
-# Ultralytics YOLOv3 🚀, AGPL-3.0 license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 # Parameters
 nc: 80 # number of classes

--- a/models/yolov3.yaml
+++ b/models/yolov3.yaml
@@ -1,4 +1,4 @@
-# Ultralytics YOLOv3 🚀, AGPL-3.0 license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 # Parameters
 nc: 80 # number of classes

--- a/models/yolov5l.yaml
+++ b/models/yolov5l.yaml
@@ -1,4 +1,4 @@
-# Ultralytics YOLOv3 🚀, AGPL-3.0 license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 # Parameters
 nc: 80 # number of classes

--- a/models/yolov5m.yaml
+++ b/models/yolov5m.yaml
@@ -1,4 +1,4 @@
-# Ultralytics YOLOv3 🚀, AGPL-3.0 license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 # Parameters
 nc: 80 # number of classes

--- a/models/yolov5n.yaml
+++ b/models/yolov5n.yaml
@@ -1,4 +1,4 @@
-# Ultralytics YOLOv3 🚀, AGPL-3.0 license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 # Parameters
 nc: 80 # number of classes

--- a/models/yolov5s.yaml
+++ b/models/yolov5s.yaml
@@ -1,4 +1,4 @@
-# Ultralytics YOLOv3 🚀, AGPL-3.0 license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 # Parameters
 nc: 80 # number of classes

--- a/models/yolov5x.yaml
+++ b/models/yolov5x.yaml
@@ -1,4 +1,4 @@
-# Ultralytics YOLOv3 🚀, AGPL-3.0 license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 # Parameters
 nc: 80 # number of classes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
-# Ultralytics YOLOv3 🚀, AGPL-3.0 license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 # Overview:
 # This pyproject.toml file manages the build, packaging, and distribution of the Ultralytics library.

--- a/utils/google_app_engine/app.yaml
+++ b/utils/google_app_engine/app.yaml
@@ -1,4 +1,4 @@
-# Ultralytics YOLOv3 🚀, AGPL-3.0 license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 runtime: custom
 env: flex


### PR DESCRIPTION
This PR updates all YAML file headers to use a standardized license format. 🔄

### Changes:

- 📝 Standardized header: `# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license`
- 🧹 Ensures consistent spacing after headers
- 🔍 Applies to all YAML files except those in `venv`

Learn more about [Ultralytics licensing](https://ultralytics.com/license) 📚

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Updated license information across repository files to standardize references to the Ultralytics AGPL-3.0 license.

### 📊 Key Changes  
- Replaced "Ultralytics YOLOv3 🚀, AGPL-3.0 license" headers with standardized "Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license" across all YAML, workflow, model, and utility files.  
- Updated license references in CI/CD configuration files, dataset YAMLs, models, hyperparameter YAMLs, and other configuration files.  

### 🎯 Purpose & Impact  
- **Clarity**: Simplifies and standardizes how the license is referenced, ensuring consistency across all project files.  
- **Transparency**: Adds a direct link to the license details for easier access and compliance for external contributors or users.  
- **No Functional Changes**: These are documentation updates and do not impact the functionality of the code or workflows.  

🚀 Cleaner documentation means better usability for contributors and users alike!