### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -4,6 +4,9 @@
 
 name: YOLOv3 CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [master]


### PR DESCRIPTION
Potential fix for [https://github.com/ultralytics/yolov3/security/code-scanning/8](https://github.com/ultralytics/yolov3/security/code-scanning/8)

To fix the issue, add a `permissions` block at the root level of the workflow file. This block will explicitly limit the permissions of the `GITHUB_TOKEN` to `contents: read`, which is sufficient for the tasks performed in this workflow. This change ensures that the workflow does not inherit overly permissive defaults and adheres to GitHub's security recommendations.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Improved security settings for YOLOv3's automated testing workflow. 🔒

### 📊 Key Changes  
- Added explicit permissions (`contents: read`) to the GitHub Actions workflow configuration.

### 🎯 Purpose & Impact  
- Enhances security by limiting workflow access to read-only for repository contents.
- Reduces potential risks from automated processes, keeping your codebase safer.
- No impact on user-facing features or model performance—this is a behind-the-scenes improvement.