### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/merge-main-into-prs.yml
+++ b/.github/workflows/merge-main-into-prs.yml
@@ -15,6 +15,9 @@ jobs:
   Merge:
     if: github.repository == 'ultralytics/yolov3'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/ultralytics/yolov3/security/code-scanning/7](https://github.com/ultralytics/yolov3/security/code-scanning/7)

To fix this problem, we should explicitly specify the required permissions for the job or workflow. According to GitHub's least-privilege approach, we add the `permissions` block in the job definition (applying to the single `Merge` job). This workflow operates on pull requests (using `pr.update_branch()` with the GitHub API), so it needs `contents: read` (to checkout and read the repo) and `pull-requests: write` (to update PR branches). These can be set by inserting the `permissions` key at the same indentation level as `runs-on` under the `Merge` job.

**Where to change:**  
In `.github/workflows/merge-main-into-prs.yml`, add the following under line 17 (`runs-on: ubuntu-latest`):
```yaml
permissions:
  contents: read
  pull-requests: write
```
No imports or additional modifications are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Explicitly sets GitHub Actions permissions for the “merge main into PRs” workflow to improve security and reliability. 🔒🤖

### 📊 Key Changes
- Added a `permissions` block to the workflow:
  - `contents: read`
  - `pull-requests: write`

### 🎯 Purpose & Impact
- Enhances security by using least-privilege permissions for the GitHub token. 🛡️
- Prevents permission-related failures when the workflow updates PRs. ✅
- Increases CI reliability for contributors by ensuring automatic PR updates from `main` work as intended. 🚀
- No impact on YOLOv3 runtime, training, or user-facing features. 👌