### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,6 +3,7 @@
 # Builds ultralytics/yolov3:latest images on DockerHub https://hub.docker.com/r/ultralytics/yolov3
 
 name: Publish Docker Images
+
 permissions:
   contents: read
 


### PR DESCRIPTION
Potential fix for [https://github.com/ultralytics/yolov3/security/code-scanning/4](https://github.com/ultralytics/yolov3/security/code-scanning/4)

**General description:**  
Restrict the GITHUB_TOKEN permissions for this workflow to the minimum required: `contents: read`.

**Detailed description:**  
Add a `permissions:` block at the root of the workflow configuration (after `name:` and before `on:`), setting `contents: read`. This explicitly grants only read permissions for the repository contents—which is all this workflow requires.

**Changes to make:**  
Edit `.github/workflows/docker.yml` by inserting a block:
```yaml
permissions:
  contents: read
```
immediately below the `name: Publish Docker Images` line (after line 5 and before line 7).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Adds least-privilege permissions to the Docker publish GitHub Actions workflow to improve CI security without changing user-facing behavior. 🔒🐳

### 📊 Key Changes
- GitHub Actions workflow (`.github/workflows/docker.yml`) now explicitly sets `permissions: contents: read`.
- No code, model, or training changes—CI-only update.

### 🎯 Purpose & Impact
- Enhances security by following GitHub’s least-privilege best practices, preventing unnecessary write access from `GITHUB_TOKEN`. 🔐
- Ensures the Docker image publish workflow can read repository content reliably, especially in restricted org settings. ✅
- No impact on how you use YOLOv3; builds and images remain unchanged. 🚀