### PR TITLE
Bump slackapi/slack-github-action from v3.0.1 to v3.0.2 in /.github/workflows

### DIFF
--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -119,7 +119,7 @@ jobs:
     steps:
       - name: Check for failure and notify
         if: (needs.Tests.result == 'failure' || needs.Tests.result == 'cancelled') && github.repository == 'ultralytics/yolov3' && (github.event_name == 'schedule' || github.event_name == 'push')
-        uses: slackapi/slack-github-action@v3.0.1
+        uses: slackapi/slack-github-action@v3.0.2
         with:
           webhook-type: incoming-webhook
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_YOLO }}


### PR DESCRIPTION
Bump slackapi/slack-github-action from v3.0.1 to v3.0.2 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR makes a small maintenance update by bumping the Slack GitHub Action in CI from `v3.0.1` to `v3.0.2`.

### 📊 Key Changes
- Updated the GitHub Actions step in `.github/workflows/ci-testing.yml`
- Changed the Slack notification action from `slackapi/slack-github-action@v3.0.1` to `slackapi/slack-github-action@v3.0.2`
- This affects the workflow step that sends Slack alerts when scheduled or push-based CI tests fail or are canceled in `ultralytics/yolov3` 📣

### 🎯 Purpose & Impact
- Improves workflow maintenance by keeping a dependency in GitHub Actions up to date ✅
- May include upstream bug fixes, minor reliability improvements, or security updates from the Slack action package 🔒
- Helps ensure CI failure notifications continue working smoothly for the team, with little to no impact on end users 👷
- Low-risk change overall, since it only updates the version of an existing CI notification tool 🚦