### PR TITLE
Fix lychee install workflow

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -27,7 +27,9 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install lychee
-        run: curl -sSfL "https://github.com/lycheeverse/lychee/releases/latest/download/lychee-x86_64-unknown-linux-gnu.tar.gz" | sudo tar xz -C /usr/local/bin
+        run: |
+          curl -sSfL "https://github.com/lycheeverse/lychee/releases/latest/download/lychee-x86_64-unknown-linux-gnu.tar.gz" |
+            sudo tar xz --strip-components=1 -C /usr/local/bin lychee-x86_64-unknown-linux-gnu/lychee
 
       - name: Test Markdown and HTML links with retry
         uses: ultralytics/actions/retry@main


### PR DESCRIPTION
## Summary\n- Extract the lychee binary from the nested release archive path\n- Match the working handbook install command pattern\n\n## Tests\n- actionlint .github/workflows/links.yml\n- git diff --check -- .github/workflows/links.yml\n- Verified latest lychee archive contains lychee-x86_64-unknown-linux-gnu/lychee

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR fixes the GitHub link-checking workflow by making the `lychee` installation step extract the correct binary path more reliably.

### 📊 Key Changes
- Updated `.github/workflows/links.yml` in the **Install lychee** step.
- Changed the extraction command from unpacking the whole archive directly into `/usr/local/bin` to extracting only the `lychee` binary from its nested folder.
- Added `--strip-components=1` so the binary is placed correctly without preserving the archive’s internal directory structure.
- Kept the rest of the link-testing workflow unchanged, including the retry-based Markdown and HTML link checks.

### 🎯 Purpose & Impact
- ✅ Improves the reliability of the CI workflow that checks documentation links.
- 🚫 Reduces the chance of installation failures caused by archive structure changes or incorrect extraction paths.
- 🔍 Helps ensure broken links are still caught consistently in automated checks.
- 🛠️ Benefits maintainers most directly, but also supports all users by keeping repository documentation and links healthier over time.