### PR TITLE
Remove pip from App Engine requirements

### DIFF
--- a/utils/google_app_engine/additional_requirements.txt
+++ b/utils/google_app_engine/additional_requirements.txt
@@ -1,5 +1,4 @@
 # add these requirements in your app on top of the existing ones
-pip==26.0
 Flask==3.1.3
 gunicorn==23.0.0
 werkzeug>=3.0.1 # not directly required, pinned by Snyk to avoid a vulnerability


### PR DESCRIPTION
## Summary
- remove the App Engine supplemental `pip==26.0` runtime dependency flagged by Dependabot/GHSA-58qw-9mgm-455v
- keep the actual App Engine app dependencies unchanged

## Validation
- `git diff --check`
- `/tmp/yolov3-pip-alert-venv/bin/python -m pip install --dry-run -r utils/google_app_engine/additional_requirements.txt`
- `rg -n "^pip\b|^pip[=<>~!]" utils/google_app_engine/additional_requirements.txt requirements.txt` returned no matches

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🧹 This PR removes the explicit `pip==26.0` requirement from the Google App Engine extra dependencies file, simplifying deployment requirements.

### 📊 Key Changes
- Removed `pip==26.0` from `utils/google_app_engine/additional_requirements.txt`
- Kept the existing web app dependencies unchanged:
  - `Flask==3.1.3`
  - `gunicorn==23.0.0`
  - `werkzeug>=3.0.1`

### 🎯 Purpose & Impact
- Reduces unnecessary dependency pinning in Google App Engine setups ✅
- Helps avoid potential installation or environment conflicts caused by forcing a specific `pip` version ⚙️
- Makes deployment configuration a bit cleaner and more maintainable for users deploying YOLOv3 with Google App Engine 🚀