### PR TITLE
Bump slackapi/slack-github-action from v3.0.2 to v3.0.3 in /.github/workflows

### DIFF
--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -119,7 +119,7 @@ jobs:
     steps:
       - name: Check for failure and notify
         if: (needs.Tests.result == 'failure' || needs.Tests.result == 'cancelled') && github.repository == 'ultralytics/yolov3' && (github.event_name == 'schedule' || github.event_name == 'push')
-        uses: slackapi/slack-github-action@v3.0.2
+        uses: slackapi/slack-github-action@v3.0.3
         with:
           webhook-type: incoming-webhook
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_YOLO }}


### PR DESCRIPTION
Bump slackapi/slack-github-action from v3.0.2 to v3.0.3 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR makes a small maintenance update by upgrading the Slack GitHub Action used in CI failure notifications from `v3.0.2` to `v3.0.3`.

### 📊 Key Changes
- ⬆️ Updated `.github/workflows/ci-testing.yml` to use `slackapi/slack-github-action@v3.0.3` instead of `@v3.0.2`.
- 📣 The change affects the workflow step that sends Slack alerts when scheduled or push-based CI tests fail or are cancelled in `ultralytics/yolov3`.
- 🛠️ No model code, training logic, or inference behavior was changed.

### 🎯 Purpose & Impact
- ✅ Keeps CI infrastructure up to date with the latest patch release of the Slack notification action.
- 🔒 May improve reliability, compatibility, or minor bug fixes in failure alert delivery.
- 👀 Helps maintainers notice broken or cancelled test runs quickly through Slack notifications.
- 🚫 No direct impact on end users, model performance, or YOLO training/inference results.