### PR TITLE
Run Python dependency updates monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
   - package-ecosystem: pip
     directory: "/"
     schedule:
-      interval: weekly
+      interval: monthly
       time: "04:00"
     open-pull-requests-limit: 10
     labels:


### PR DESCRIPTION
## Summary
- change Dependabot `pip` updates from weekly to monthly
- leave GitHub Actions dependency update cadence unchanged

## Validation
- `git diff --check -- .github/dependabot.yml`
- `ruby -e 'require "yaml"; YAML.load_file(".github/dependabot.yml")'`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
📅 This PR reduces Dependabot update frequency for Python packages in `ultralytics/yolov3` from weekly to monthly.

### 📊 Key Changes
- Changed the `.github/dependabot.yml` configuration for the `pip` ecosystem.
- Updated the scheduled dependency check interval from `weekly` to `monthly`.
- No source code, model behavior, or training/inference logic was changed.

### 🎯 Purpose & Impact
- Reduces the number of automated dependency update PRs 🧹
- Helps maintainers spend less time reviewing frequent package bump requests.
- Can make repository maintenance quieter and more manageable overall.
- May slightly delay non-urgent dependency updates, but improves workflow efficiency for the team.