### PR TITLE
Fix ClearML documentation links

### DIFF
--- a/utils/loggers/clearml/README.md
+++ b/utils/loggers/clearml/README.md
@@ -2,13 +2,13 @@
 
 # ClearML Integration for Ultralytics YOLO
 
-This guide details how to integrate [ClearML](https://clear.ml/), a leading open-source MLOps platform, with your Ultralytics YOLO projects. ClearML streamlines the entire machine learning lifecycle—from experiment tracking to deployment—making it easier to manage and scale your computer vision workflows.
+This guide details how to integrate [ClearML](https://www.clear.ml/), a leading open-source MLOps platform, with your Ultralytics YOLO projects. ClearML streamlines the entire machine learning lifecycle—from experiment tracking to deployment—making it easier to manage and scale your computer vision workflows.
 
 <img align="center" src="https://github.com/thepycoder/clearml_screenshots/raw/main/logos_dark.png#gh-light-mode-only" alt="Clear|ML"><img align="center" src="https://github.com/thepycoder/clearml_screenshots/raw/main/logos_light.png#gh-dark-mode-only" alt="Clear|ML">
 
 ## ✨ About ClearML
 
-[ClearML](https://clear.ml/) is an [open-source MLOps suite](https://github.com/clearml/clearml) that enables you to manage, automate, and orchestrate machine learning workflows efficiently. Integrating ClearML with Ultralytics YOLO unlocks several advantages:
+[ClearML](https://www.clear.ml/) is an [open-source MLOps suite](https://github.com/clearml/clearml) that enables you to manage, automate, and orchestrate machine learning workflows efficiently. Integrating ClearML with Ultralytics YOLO unlocks several advantages:
 
 - **Experiment Management**: Automatically track every YOLO training run, including code versions, configurations, metrics, and outputs in a centralized dashboard. Explore more about [Ultralytics experiment tracking integrations](https://docs.ultralytics.com/integrations/).
 - **Data Versioning**: Manage and access your custom training datasets with ClearML Data Versioning. See how [Ultralytics datasets](https://docs.ultralytics.com/datasets/) are structured.
@@ -25,7 +25,7 @@ You can leverage any combination of these tools to fit your project requirements
 To use ClearML, connect the SDK to a ClearML Server instance. You have two main options:
 
 1. **ClearML Hosted Service**: Register for a free account at the [ClearML Hosted Service](https://app.clear.ml/).
-2. **Self-Hosted Server**: Deploy your own [ClearML Server](https://clear.ml/docs/latest/docs/deploying_clearml/clearml_server) for full control and data privacy.
+2. **Self-Hosted Server**: Deploy your own [ClearML Server](https://docs.clear.ml/docs/latest/docs/deploying_clearml/clearml_server) for full control and data privacy.
 
 Follow these steps to get started:
 
@@ -172,7 +172,7 @@ This script clones the template task, applies new hyperparameters suggested by t
 
 ClearML Agent enables running experiments on remote machines, such as on-premises servers or cloud GPUs. The agent fetches tasks from a queue, replicates the original environment (code, packages, uncommitted changes), executes the task, and reports results back to the ClearML Server.
 
-- **Learn More**: Watch the [ClearML Agent Introduction](https://www.youtube.com/watch?v=MX3BrXnaULs) or read the [ClearML Agent documentation](https://clear.ml/docs/latest/docs/clearml_agent).
+- **Learn More**: Watch the [ClearML Agent Introduction](https://www.youtube.com/watch?v=MX3BrXnaULs) or read the [ClearML Agent documentation](https://docs.clear.ml/docs/latest/docs/clearml_agent).
 
 Turn any machine into a ClearML Agent by running:
 


### PR DESCRIPTION
## Summary
- update ClearML product links to the canonical www.clear.ml host
- update ClearML documentation links to docs.clear.ml to avoid link checker 415 responses

## Tests
- /tmp/codex-bin/lychee --scheme https --timeout 60 --insecure --accept 100..=103,200..=299,401,403,429,500,502,999 --exclude-all-private --exclude 'https?://(www\.)?(linkedin\.com|twitter\.com|x\.com|instagram\.com|kaggle\.com|fonts\.gstatic\.com|url\.com)' --exclude-path './**/ci.yml' --header 'User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.6478.183 Safari/537.36' utils/loggers/clearml/README.md

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔗 This PR refreshes the ClearML integration README by correcting outdated ClearML URLs, improving documentation reliability for YOLO users.

### 📊 Key Changes
- Updated ClearML website links from `clear.ml` to `www.clear.ml` in the ClearML integration guide.
- Fixed outdated documentation links for:
  - ClearML Server deployment
  - ClearML Agent documentation
- Kept the README content and integration workflow unchanged; this is a documentation-only cleanup. 🧹

### 🎯 Purpose & Impact
- Helps users reach the correct ClearML pages without hitting broken or outdated links. ✅
- Improves the onboarding experience for anyone setting up ClearML with Ultralytics YOLO. 🚀
- Reduces confusion when following setup steps for hosted, self-hosted, and agent-based ClearML workflows.
- No code, training, or model behavior changes, so there is no impact on runtime functionality. 🔒