### PR TITLE
Revert "Update ultralytics requirement from >=8.4.47 to >=8.4.58"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ dependencies = [
     "pandas>=1.1.4",
     "packaging", # general utilities
     "seaborn>=0.11.0", # plotting
-    "ultralytics>=8.4.58",
+    "ultralytics>=8.4.47",
 ]
 
 # Optional dependencies ------------------------------------------------------------------------------------------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ thop>=0.1.1                  # Model profiling - FLOPs and parameter count
 torch>=1.8.0                 # Core PyTorch for training/inference
 torchvision>=0.9.0           # Torch utilities for vision (transforms, datasets)
 tqdm>=4.66.3                 # Progress bar in CLI
-ultralytics>=8.4.58          # YOLO framework library (models, training, utils)
+ultralytics>=8.4.47          # YOLO framework library (models, training, utils)
 # protobuf<=3.20.1           # For ONNX/TensorFlow export compatibility
 
 # Logging ---------------------------------------------------------------------


### PR DESCRIPTION
Reverts ultralytics/yolov3#2418

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR lowers the minimum required `ultralytics` package version from `8.4.58` to `8.4.47` to improve dependency compatibility in the `ultralytics/yolov3` project.

### 📊 Key Changes
- Updated the minimum `ultralytics` dependency in `pyproject.toml`:
  - from `ultralytics>=8.4.58`
  - to `ultralytics>=8.4.47`
- Updated the same dependency in `requirements.txt` to keep both install definitions consistent ✅
- No model code, training logic, or inference behavior was changed—this is a dependency/version requirement adjustment only.

### 🎯 Purpose & Impact
- 🧩 Improves compatibility with environments that already use `ultralytics` `8.4.47` or later, without forcing an upgrade to `8.4.58`
- 🚀 Makes installation and setup easier for users who may have hit version conflicts with the newer minimum requirement
- 🔒 Reduces friction in dependency management while still keeping the project tied to a relatively recent Ultralytics package version
- 👥 Likely helps a broader set of users run YOLOv3 successfully across different systems and existing Python environments