### PR TITLE
Refactor Docker publish workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,50 +15,63 @@ on:
 jobs:
   docker:
     if: github.repository == 'ultralytics/yolov3'
-    name: Push Docker image to Docker Hub
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
+    name: Build ${{ matrix.tag }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - dockerfile: utils/docker/Dockerfile-arm64
+            tag: latest-arm64
+            platform: linux/arm64
+            runs_on: ubuntu-24.04-arm
+          - dockerfile: utils/docker/Dockerfile-cpu
+            tag: latest-cpu
+            platform: linux/amd64
+            runs_on: ubuntu-latest
+          - dockerfile: utils/docker/Dockerfile
+            tag: latest
+            platform: linux/amd64
+            runs_on: ubuntu-latest
+    runs-on: ${{ matrix.runs_on }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v6
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        with:
+          fetch-depth: 0 # copy full .git directory to access full git history in Docker images
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v4
+        uses: ultralytics/actions/retry@main
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          run: |
+            if ! out=$(printf '%s' "$DOCKERHUB_TOKEN" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin 2>&1); then
+              printf '%s\n' "$out" >&2
+              exit 1
+            fi
+            echo "Logged in to docker.io"
 
-      - name: Build and push arm64 image
-        uses: docker/build-push-action@v7
-        continue-on-error: true
+      - name: Build Docker image
+        uses: ultralytics/actions/retry@main
         with:
-          context: .
-          platforms: linux/arm64
-          file: utils/docker/Dockerfile-arm64
-          push: true
-          tags: ultralytics/yolov3:latest-arm64
+          timeout_minutes: 120
+          retry_delay_seconds: 60
+          retries: 2
+          run: |
+            docker build \
+              --platform ${{ matrix.platform }} \
+              --label "org.opencontainers.image.source=https://github.com/ultralytics/yolov3" \
+              --label "org.opencontainers.image.description=Ultralytics YOLOv3 image" \
+              --label "org.opencontainers.image.licenses=AGPL-3.0-or-later" \
+              -f ${{ matrix.dockerfile }} \
+              -t ultralytics/yolov3:${{ matrix.tag }} \
+              .
 
-      - name: Build and push CPU image
-        uses: docker/build-push-action@v7
-        continue-on-error: true
+      - name: Push Docker image
+        uses: ultralytics/actions/retry@main
         with:
-          context: .
-          file: utils/docker/Dockerfile-cpu
-          push: true
-          tags: ultralytics/yolov3:latest-cpu
-
-      - name: Build and push GPU image
-        uses: docker/build-push-action@v7
-        continue-on-error: true
-        with:
-          context: .
-          file: utils/docker/Dockerfile
-          push: true
-          tags: ultralytics/yolov3:latest
+          timeout_minutes: 15
+          retry_delay_seconds: 300
+          retries: 2
+          run: docker push ultralytics/yolov3:${{ matrix.tag }}


### PR DESCRIPTION
## Summary\n- replace the QEMU/Buildx/build-push action chain with native runner matrix builds\n- run ARM builds on ubuntu-24.04-arm and amd64 builds on ubuntu-latest\n- wrap Docker Hub login, build, and push operations with ultralytics/actions/retry\n\n## Validation\n- actionlint .github/workflows/docker.yml\n- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/docker.yml'); puts 'ok'"

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🐳 This PR redesigns the YOLOv3 Docker GitHub Actions workflow to build and push Docker images more reliably across CPU, GPU, and ARM64 targets.

### 📊 Key Changes
- 🔄 Replaced the single Docker publish job with a **matrix-based workflow** that builds three image variants:
  - `latest-arm64` from `Dockerfile-arm64`
  - `latest-cpu` from `Dockerfile-cpu`
  - `latest` from the default Dockerfile
- 🖥️ Added **platform-specific runners**:
  - ARM64 builds now run on `ubuntu-24.04-arm`
  - AMD64 builds run on `ubuntu-latest`
- 🧱 Switched from `docker/build-push-action` and QEMU/Buildx setup to direct `docker build` and `docker push` commands
- 🔁 Wrapped both Docker login and image build/push steps with `ultralytics/actions/retry@main` to automatically retry failed operations
- 📚 Updated checkout to use `fetch-depth: 0`, allowing the full Git history to be included during Docker builds
- 🏷️ Added OCI image labels for source, description, and license metadata

### 🎯 Purpose & Impact
- ✅ **Improves reliability** by adding retries for login, build, and push steps, helping reduce failures from temporary network or Docker Hub issues
- ⚡ **Simplifies the workflow** by removing extra Buildx and QEMU setup, making the CI pipeline easier to maintain
- 🌍 **Strengthens multi-platform support** with clearer handling for ARM64 and AMD64 image builds
- 📦 **Produces better container metadata**, which helps users and tooling identify image origin and licensing
- 🛠️ **May reduce flaky CI runs** and make Docker image publishing more predictable for maintainers and users pulling `ultralytics/yolov3` images