### PR TITLE
Use Ubuntu 24.04 Docker bases

### DIFF
--- a/utils/docker/Dockerfile
+++ b/utils/docker/Dockerfile
@@ -1,7 +1,7 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-# Builds ultralytics/yolov5:latest image on DockerHub https://hub.docker.com/r/ultralytics/yolov3
-# Image is CUDA-optimized for YOLOv5 single/multi-GPU training and inference
+# Builds ultralytics/yolov3:latest image on DockerHub https://hub.docker.com/r/ultralytics/yolov3
+# Image is CUDA-optimized for YOLOv3 single/multi-GPU training and inference
 
 # Start FROM PyTorch image https://hub.docker.com/r/pytorch/pytorch
 FROM pytorch/pytorch:2.8.0-cuda12.8-cudnn9-runtime
@@ -26,7 +26,7 @@ WORKDIR /usr/src/app
 
 # Copy contents
 # COPY . /usr/src/app  (issues as not a .git directory)
-RUN git clone https://github.com/ultralytics/yolov5 /usr/src/app
+RUN git clone https://github.com/ultralytics/yolov3 /usr/src/app
 
 # Install pip packages
 COPY requirements.txt .
@@ -45,22 +45,22 @@ ENV DEBIAN_FRONTEND teletype
 # Usage Examples -------------------------------------------------------------------------------------------------------
 
 # Build and Push
-# t=ultralytics/yolov5:latest && sudo docker build -f utils/docker/Dockerfile -t $t . && sudo docker push $t
+# t=ultralytics/yolov3:latest && sudo docker build -f utils/docker/Dockerfile -t $t . && sudo docker push $t
 
 # Pull and Run
-# t=ultralytics/yolov5:latest && sudo docker pull $t && sudo docker run -it --ipc=host --gpus all $t
+# t=ultralytics/yolov3:latest && sudo docker pull $t && sudo docker run -it --ipc=host --gpus all $t
 
 # Pull and Run with local directory access
-# t=ultralytics/yolov5:latest && sudo docker pull $t && sudo docker run -it --ipc=host --gpus all -v "$(pwd)"/datasets:/usr/src/datasets $t
+# t=ultralytics/yolov3:latest && sudo docker pull $t && sudo docker run -it --ipc=host --gpus all -v "$(pwd)"/datasets:/usr/src/datasets $t
 
 # Kill all
 # sudo docker kill $(sudo docker ps -q)
 
 # Kill all image-based
-# sudo docker kill $(sudo docker ps -qa --filter ancestor=ultralytics/yolov5:latest)
+# sudo docker kill $(sudo docker ps -qa --filter ancestor=ultralytics/yolov3:latest)
 
 # DockerHub tag update
-# t=ultralytics/yolov5:latest tnew=ultralytics/yolov5:v6.2 && sudo docker pull $t && sudo docker tag $t $tnew && sudo docker push $tnew
+# t=ultralytics/yolov3:latest tnew=ultralytics/yolov3:v6.2 && sudo docker pull $t && sudo docker tag $t $tnew && sudo docker push $tnew
 
 # Clean up
 # sudo docker system prune -a --volumes
@@ -72,4 +72,4 @@ ENV DEBIAN_FRONTEND teletype
 # python -m torch.distributed.run --nproc_per_node 2 --master_port 1 train.py --epochs 3
 
 # GCP VM from Image
-# docker.io/ultralytics/yolov5:latest
+# docker.io/ultralytics/yolov3:latest

--- a/utils/docker/Dockerfile-arm64
+++ b/utils/docker/Dockerfile-arm64
@@ -1,16 +1,17 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-# Builds ultralytics/yolov5:latest-arm64 image on DockerHub https://hub.docker.com/r/ultralytics/yolov3
+# Builds ultralytics/yolov3:latest-arm64 image on DockerHub https://hub.docker.com/r/ultralytics/yolov3
 # Image is aarch64-compatible for Apple M1 and other ARM architectures i.e. Jetson Nano and Raspberry Pi
 
 # Start FROM Ubuntu image https://hub.docker.com/_/ubuntu
-FROM arm64v8/ubuntu:22.10
+FROM arm64v8/ubuntu:24.04
 
 # Downloads to user config dir
 ADD https://ultralytics.com/assets/Arial.ttf https://ultralytics.com/assets/Arial.Unicode.ttf /root/.config/Ultralytics/
 
 # Install linux packages
-ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_FRONTEND=noninteractive \
+    PIP_BREAK_SYSTEM_PACKAGES=1
 RUN apt update
 RUN TZ=Etc/UTC apt install -y tzdata
 RUN apt install --no-install-recommends -y python3-pip git zip curl htop gcc libgl1 libglib2.0-0 libpython3-dev
@@ -18,7 +19,7 @@ RUN apt install --no-install-recommends -y python3-pip git zip curl htop gcc lib
 
 # Install pip packages
 COPY requirements.txt .
-RUN python3 -m pip install --upgrade pip wheel
+RUN python3 -m pip install wheel
 RUN pip install --no-cache -r requirements.txt albumentations gsutil notebook \
     coremltools onnx onnxruntime
     # tensorflow-aarch64 tensorflowjs \
@@ -29,14 +30,14 @@ WORKDIR /usr/src/app
 
 # Copy contents
 # COPY . /usr/src/app  (issues as not a .git directory)
-RUN git clone https://github.com/ultralytics/yolov5 /usr/src/app
+RUN git clone https://github.com/ultralytics/yolov3 /usr/src/app
 ENV DEBIAN_FRONTEND teletype
 
 
 # Usage Examples -------------------------------------------------------------------------------------------------------
 
 # Build and Push
-# t=ultralytics/yolov5:latest-arm64 && sudo docker build --platform linux/arm64 -f utils/docker/Dockerfile-arm64 -t $t . && sudo docker push $t
+# t=ultralytics/yolov3:latest-arm64 && sudo docker build --platform linux/arm64 -f utils/docker/Dockerfile-arm64 -t $t . && sudo docker push $t
 
 # Pull and Run
-# t=ultralytics/yolov5:latest-arm64 && sudo docker pull $t && sudo docker run -it --ipc=host -v "$(pwd)"/datasets:/usr/src/datasets $t
+# t=ultralytics/yolov3:latest-arm64 && sudo docker pull $t && sudo docker run -it --ipc=host -v "$(pwd)"/datasets:/usr/src/datasets $t

--- a/utils/docker/Dockerfile-cpu
+++ b/utils/docker/Dockerfile-cpu
@@ -1,10 +1,11 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-# Builds ultralytics/yolov5:latest-cpu image on DockerHub https://hub.docker.com/r/ultralytics/yolov3
-# Image is CPU-optimized for ONNX, OpenVINO and PyTorch YOLOv5 deployments
+# Builds ultralytics/yolov3:latest-cpu image on DockerHub https://hub.docker.com/r/ultralytics/yolov3
+# Image is CPU-optimized for ONNX, OpenVINO and PyTorch YOLOv3 deployments
 
 # Start FROM Ubuntu image https://hub.docker.com/_/ubuntu
-FROM ubuntu:23.10
+FROM ubuntu:24.04
+ENV PIP_BREAK_SYSTEM_PACKAGES=1
 
 # Downloads to user config dir
 ADD https://ultralytics.com/assets/Arial.ttf https://ultralytics.com/assets/Arial.Unicode.ttf /root/.config/Ultralytics/
@@ -15,12 +16,9 @@ RUN apt update \
     && apt install --no-install-recommends -y python3-pip git zip curl htop libgl1 libglib2.0-0 libpython3-dev gnupg g++ libusb-1.0-0
 # RUN alias python=python3
 
-# Remove python3.11/EXTERNALLY-MANAGED or use 'pip install --break-system-packages' avoid 'externally-managed-environment' Ubuntu nightly error
-RUN rm -rf /usr/lib/python3.11/EXTERNALLY-MANAGED
-
 # Install pip packages
 COPY requirements.txt .
-RUN python3 -m pip install --upgrade pip wheel
+RUN python3 -m pip install wheel
 RUN pip install --no-cache -r requirements.txt albumentations gsutil notebook \
     coremltools onnx onnx-simplifier onnxruntime 'openvino-dev>=2023.0' \
     # tensorflow tensorflowjs \
@@ -32,13 +30,13 @@ WORKDIR /usr/src/app
 
 # Copy contents
 # COPY . /usr/src/app  (issues as not a .git directory)
-RUN git clone https://github.com/ultralytics/yolov5 /usr/src/app
+RUN git clone https://github.com/ultralytics/yolov3 /usr/src/app
 
 
 # Usage Examples -------------------------------------------------------------------------------------------------------
 
 # Build and Push
-# t=ultralytics/yolov5:latest-cpu && sudo docker build -f utils/docker/Dockerfile-cpu -t $t . && sudo docker push $t
+# t=ultralytics/yolov3:latest-cpu && sudo docker build -f utils/docker/Dockerfile-cpu -t $t . && sudo docker push $t
 
 # Pull and Run
-# t=ultralytics/yolov5:latest-cpu && sudo docker pull $t && sudo docker run -it --ipc=host -v "$(pwd)"/datasets:/usr/src/datasets $t
+# t=ultralytics/yolov3:latest-cpu && sudo docker pull $t && sudo docker run -it --ipc=host -v "$(pwd)"/datasets:/usr/src/datasets $t


### PR DESCRIPTION
## Summary\n- move CPU and ARM64 Docker images from EOL Ubuntu bases to Ubuntu 24.04 LTS\n- keep the EXTERNALLY-MANAGED cleanup version-agnostic for the new Python path\n- correct YOLOv3 Dockerfiles that still cloned and documented ultralytics/yolov5\n\n## Evidence\n- post-merge Docker run 27163942879 failed because ubuntu:23.10 and arm64v8/ubuntu:22.10 apt repositories returned 404\n- ubuntu:24.04 amd64 apt/package install smoke passed locally\n- arm64v8/ubuntu:24.04 apt/package install smoke passed locally\n\n## Validation\n- rg -n "FROM .*ubuntu:(22\.04|22\.10|23\.10)|mantic|kinetic|ultralytics/yolov5" utils/docker .github/workflows || true\n- git diff --check

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
This PR fixes and modernizes the YOLOv3 Docker setup 🐳 by replacing leftover YOLOv5 references, updating base images, and improving Python package installation compatibility.

### 📊 Key Changes
- Updated all Docker image names, comments, example commands, and Git clone targets from `yolov5` to `yolov3` ✅
- Fixed the main Dockerfile so it now clones the correct repository: `ultralytics/yolov3`
- Updated ARM64 Docker base image from `ubuntu:22.10` to `ubuntu:24.04` 🚀
- Updated CPU Docker base image from `ubuntu:23.10` to `ubuntu:24.04`
- Improved pip install handling for newer Ubuntu versions by adding `PIP_BREAK_SYSTEM_PACKAGES=1`
- Removed the manual workaround that deleted Ubuntu’s `EXTERNALLY-MANAGED` file, replacing it with a cleaner approach 🛠️
- Simplified pip setup by no longer upgrading pip explicitly in ARM64 and CPU Dockerfiles, and installing `wheel` directly

### 🎯 Purpose & Impact
- Ensures Docker images and instructions now correctly match the YOLOv3 repository, reducing confusion for users 📦
- Prevents users from accidentally building or pulling mislabeled YOLOv5-based containers
- Improves compatibility with newer Ubuntu releases, especially for CPU and ARM64 environments
- Makes Docker builds more reliable on devices like Apple Silicon, Jetson, and Raspberry Pi 🌍
- Replaces a fragile system-file deletion hack with a cleaner package installation method, which should be safer and easier to maintain
- Overall, this is mainly a maintenance and correctness update, but it has real usability benefits for anyone building or running YOLOv3 in Docker 👍