### PR TITLE
Stabilize broken link checks

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -45,6 +45,7 @@ jobs:
             --accept 100..=103,200..=299,401,403,429,500,502,999 \
             --exclude-all-private \
             --exclude 'https?://(www\.)?(linkedin\.com|twitter\.com|x\.com|instagram\.com|kaggle\.com|fonts\.gstatic\.com|url\.com)' \
+            --exclude 'https?://([^/]+\.)?clear\.ml(/.*)?' \
             --exclude-path './**/ci-testing.yml' \
             --github-token ${{ secrets.GITHUB_TOKEN }} \
             --header "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.6478.183 Safari/537.36" \
@@ -71,6 +72,7 @@ jobs:
             --accept 100..=103,200..=299,401,403,429,500,502,999 \
             --exclude-all-private \
             --exclude 'https?://(www\.)?(linkedin\.com|twitter\.com|x\.com|instagram\.com|kaggle\.com|fonts\.gstatic\.com|url\.com)' \
+            --exclude 'https?://([^/]+\.)?clear\.ml(/.*)?' \
             --exclude 'https?://[^[:space:]]*(%7B|%7D|\{|\}|sentry\.io|google-analytics\.com/mp/collect|storage\.googleapis\.com|packages\.cloud\.google\.com/apt)(/.*)?' \
             --exclude 'https://github\.com/ultralytics/assets/releases/download/v0\.0\.0' \
             --exclude 'https?://(bit\.ly/yolov5-readme-comet2|cutt\.ly/yolov5-notebook-clearml)/?' \

--- a/tutorial.ipynb
+++ b/tutorial.ipynb
@@ -20,8 +20,8 @@
    },
    "source": [
     "<div align=\"center\">\n",
-    "  <a href=\"https://ultralytics.com/yolo\" target=\"_blank\">\n",
-    "    <img width=\"1024\" src=\"https://raw.githubusercontent.com/ultralytics/assets/main/yolov3/banner-yolov3.png\">\n",
+    "  <a href='https://ultralytics.com/yolo' target='_blank'>\n",
+    "    <img width='1024' src='https://raw.githubusercontent.com/ultralytics/assets/main/yolov3/banner-yolov3.png'>\n",
     "  </a>\n",
     "\n",
     "  [中文](https://docs.ultralytics.com/zh/) | [한국어](https://docs.ultralytics.com/ko/) | [日本語](https://docs.ultralytics.com/ja/) | [Русский](https://docs.ultralytics.com/ru/) | [Deutsch](https://docs.ultralytics.com/de/) | [Français](https://docs.ultralytics.com/fr/) | [Español](https://docs.ultralytics.com/es/) | [Português](https://docs.ultralytics.com/pt/) | [Türkçe](https://docs.ultralytics.com/tr/) | [Tiếng Việt](https://docs.ultralytics.com/vi/) | [العربية](https://docs.ultralytics.com/ar/)\n",


### PR DESCRIPTION
## Summary
- exclude ClearML domains from scheduled and manual lychee runs
- fix notebook banner HTML quoting so lychee parses the raw GitHub image URL correctly

## Tests
- lychee scheduled Markdown/HTML surface: 339 total, 0 errors
- lychee expanded workflow-dispatch surface: 679 total, 0 errors
- jq empty tutorial.ipynb
- git diff --check

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ This PR makes small but useful maintenance updates by improving link-check workflow reliability and cleaning up HTML formatting in the YOLOv3 tutorial notebook.

### 📊 Key Changes
- 🔗 Updated `.github/workflows/links.yml` to exclude `clear.ml` links from automated link checking in two workflow sections.
- ✅ This helps avoid false link-check failures caused by external ClearML URLs.
- 🧹 Adjusted HTML in `tutorial.ipynb` to use consistent single-quote formatting for the banner link and image tag.
- 🎨 The tutorial content itself does not change; this is a formatting-only cleanup.

### 🎯 Purpose & Impact
- 🚦 Makes CI more stable by preventing unnecessary failures from external ClearML links that may be blocked, rate-limited, or inconsistent.
- ⏱️ Reduces maintenance noise for contributors, so PRs are less likely to fail for non-code-related reasons.
- 📘 Keeps the tutorial notebook markup cleaner and more consistent, which can help with readability and formatting maintenance.
- 👥 User-facing impact is minimal, but developers and maintainers benefit from a smoother workflow.