### PR TITLE
Bump actions/checkout from v6 to v7 in /.github/workflows

### DIFF
--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -35,7 +35,7 @@ jobs:
             model: yolov3-tiny
             torch: "1.8.0" # minimum supported torch (PyTorch>=1.8)
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ${{ matrix.runs_on }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0 # copy full .git directory to access full git history in Docker images
 

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -24,7 +24,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Install lychee
         run: |


### PR DESCRIPTION
Bump actions/checkout from v6 to v7 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔄 This PR updates GitHub Actions workflows in `ultralytics/yolov3` to use `actions/checkout@v7` instead of `@v6`, improving CI and automation maintenance.

### 📊 Key Changes
- Updated `actions/checkout` from `@v6` to `@v7` in the following GitHub workflow files:
  - `.github/workflows/ci-testing.yml`
  - `.github/workflows/docker.yml`
  - `.github/workflows/links.yml`
- Applied the change across key automation pipelines, including:
  - ✅ CI testing
  - 🐳 Docker image workflows
  - 🔗 Link checking

### 🎯 Purpose & Impact
- Keeps repository automation up to date with the latest GitHub Actions version 🚀
- Helps improve long-term compatibility, security, and support for CI workflows 🔒
- Reduces maintenance risk by aligning multiple workflows with the same newer action version 🛠️
- Has no direct effect on YOLOv3 model behavior or user-facing features, but helps ensure development and release pipelines remain reliable ✅