### PR TITLE
Simplify Slack notification messages

### DIFF
--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -90,4 +90,4 @@ jobs:
           webhook-type: incoming-webhook
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_YOLO }}
           payload: |
-            text: "<!channel> GitHub Actions error for ${{ github.workflow }} ❌\n\n\n*Repository:* https://github.com/${{ github.repository }}\n*Action:* https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}\n*Author:* ${{ github.actor }}\n*Event:* ${{ github.event_name }}\n"
+            text: "<!subteam^S082BPCRAJ3> *${{ github.workflow }}* ❌ `${{ github.repository }}`  <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|*Run*>"


### PR DESCRIPTION
Replaces the verbose multi-line Slack notifications with a single dense line — bold workflow name, status emoji, `${{ github.repository }}`, and a *Run* backlink — matching the format used in `ultralytics/portal`.

- Scopes the broad `<!channel>` ping down to `@yolo-team` to cut company-wide notification noise.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔔 This PR updates the GitHub Actions Slack alert format to make CI failure notifications shorter, clearer, and routed directly to a specific Slack team group.

### 📊 Key Changes
- Replaced the generic `<!channel>` Slack mention with a targeted Slack subteam mention: `<!subteam^S082BPCRAJ3>`.
- Simplified the CI failure message sent from `.github/workflows/ci-testing.yml`.
- Changed the alert content from a long multi-line message to a compact one-line format that includes:
  - the workflow name
  - the repository name
  - a direct link to the failed run
- Removed extra details from the Slack payload, such as:
  - repository URL
  - author
  - event type

### 🎯 Purpose & Impact
- 🚨 **Improves visibility:** Alerts now notify the intended Slack team directly instead of broadcasting to the entire channel.
- 🧹 **Reduces noise:** A shorter message is easier to scan and less cluttered in busy Slack channels.
- ⚡ **Speeds up response time:** The direct link to the failed GitHub Actions run helps maintainers jump into debugging faster.
- 👥 **Better team coordination:** Targeted notifications can help the right people see CI failures sooner without over-alerting others.