### PR TITLE
Bump slackapi/slack-github-action from v3.0.3 to v3.0.5 in /.github/workflows

### DIFF
--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -85,7 +85,7 @@ jobs:
     steps:
       - name: Check for failure and notify
         if: (needs.Tests.result == 'failure' || needs.Tests.result == 'cancelled') && github.repository == 'ultralytics/yolov3' && (github.event_name == 'schedule' || github.event_name == 'push')
-        uses: slackapi/slack-github-action@v3.0.3
+        uses: slackapi/slack-github-action@v3.0.5
         with:
           webhook-type: incoming-webhook
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_YOLO }}


### PR DESCRIPTION
Bump slackapi/slack-github-action from v3.0.3 to v3.0.5 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updates the Slack GitHub Action used for CI failure notifications from v3.0.3 to v3.0.5. 🔔

### 📊 Key Changes

- Updated `slackapi/slack-github-action` in the CI workflow to version `v3.0.5`.
- No changes were made to the CI tests, notification conditions, or webhook configuration.

### 🎯 Purpose & Impact

- Keeps Slack notifications aligned with a newer action release. ✅
- May provide bug fixes, reliability improvements, and compatibility updates from the Slack action.
- CI failure alerts for scheduled and push workflows should continue working as before.