### PR TITLE
Use shared setup-uv action everywhere

### DIFF
--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
-      - uses: astral-sh/setup-uv@v7
+      - uses: ultralytics/actions/setup-uv@main
       - name: Install requirements
         run: |
           torch=""

--- a/.github/workflows/merge-main-into-prs.yml
+++ b/.github/workflows/merge-main-into-prs.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.x"
-      - uses: astral-sh/setup-uv@v7
+      - uses: ultralytics/actions/setup-uv@main
       - name: Install requirements
         run: |
           uv pip install --system pygithub


### PR DESCRIPTION
## Summary

- replace both Astral uv setup steps with the shared retried owner
- preserve CI and branch-maintenance behavior

Reused: `ultralytics/actions/setup-uv@main` is the single latest-uv installer owner.

Deleted: two direct `astral-sh/setup-uv` dependencies.

## Validation

- zero `uses: astral-sh/setup-uv` occurrences
- `actionlint` on both changed workflows
- `git diff --check`
- shared owner passed Windows, Ubuntu, and macOS CI in ultralytics/actions#819

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updated GitHub Actions workflows to use Ultralytics’ centralized `setup-uv` action instead of the external Astral action. 🔧

### 📊 Key Changes

- Replaced `astral-sh/setup-uv@v7` with `ultralytics/actions/setup-uv@main` in:
  - Continuous integration testing
  - Automatic main-branch merging into pull requests
- No changes were made to application code, model behavior, or user-facing APIs.

### 🎯 Purpose & Impact

- ✅ Standardizes `uv` setup across Ultralytics repositories.
- 🔄 Centralizes maintenance and configuration of the dependency-management action.
- 🚀 Keeps CI workflows consistent while preserving existing testing and automation behavior.
- 👥 Primarily impacts contributors and repository maintainers; end users should see no direct changes.