### PR TITLE
Bump actions/setup-python from v6 to v7 in /.github/workflows

### DIFF
--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -36,7 +36,7 @@ jobs:
             torch: "1.8.0" # minimum supported torch (PyTorch>=1.8)
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
       - uses: ultralytics/actions/setup-uv@main

--- a/.github/workflows/merge-main-into-prs.yml
+++ b/.github/workflows/merge-main-into-prs.yml
@@ -19,7 +19,7 @@ jobs:
     if: github.repository == 'ultralytics/yolov3'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.x"
       - uses: ultralytics/actions/setup-uv@main


### PR DESCRIPTION
Bump actions/setup-python from v6 to v7 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updates GitHub Actions to use the latest `actions/setup-python@v7` release. ⚙️

### 📊 Key Changes

- Updated `actions/setup-python` from `v6` to `v7` in:
  - Continuous integration testing workflow.
  - Automatic main-branch merge workflow.
- No changes were made to YOLOv3 code, models, or runtime behavior.

### 🎯 Purpose & Impact

- Keeps repository automation aligned with the latest supported GitHub Action version. 🔄
- Improves workflow maintenance, compatibility, and potential reliability.
- CI tests and automated pull request updates should continue to run with no user-facing changes. ✅