### PR TITLE
Replace tqdm and GitPython with ultralytics natives

### DIFF
--- a/benchmarks.py
+++ b/benchmarks.py
@@ -36,7 +36,6 @@ if str(ROOT) not in sys.path:
 # ROOT = ROOT.relative_to(Path.cwd())  # relative
 
 import export
-from utils import notebook_init
 from utils.general import LOGGER, check_yaml, file_size, print_args
 from utils.torch_utils import select_device
 from val import run as val_det
@@ -108,7 +107,6 @@ def run(
 
     # Print results
     LOGGER.info("\n")
-    notebook_init()  # print system info
     c = ["Format", "Size (MB)", "mAP50-95", "Inference time (ms)"]
     py = pd.DataFrame(y, columns=c)
     LOGGER.info(f"\nBenchmarks complete ({time.time() - t:.2f}s)")
@@ -164,7 +162,6 @@ def test(
 
     # Print results
     LOGGER.info("\n")
-    notebook_init()  # print system info
     py = pd.DataFrame(y, columns=["Format", "Export"])
     LOGGER.info(f"\nExports complete ({time.time() - t:.2f}s)")
     LOGGER.info(str(py))

--- a/data/Argoverse.yaml
+++ b/data/Argoverse.yaml
@@ -30,15 +30,13 @@ names:
 # Download script/URL (optional) ---------------------------------------------------------------------------------------
 download: |
   import json
-
-  from tqdm import tqdm
-  from utils.general import download, Path
+  from utils.general import download, Path, TQDM
 
 
   def argoverse2yolo(set):
       labels = {}
       a = json.load(open(set, "rb"))
-      for annot in tqdm(a['annotations'], desc=f"Converting {set} to YOLO format..."):
+      for annot in TQDM(a['annotations'], desc=f"Converting {set} to YOLO format..."):
           img_id = annot['image_id']
           img_name = a['images'][img_id]['name']
           img_label_name = f'{img_name[:-3]}txt'

--- a/data/Objects365.yaml
+++ b/data/Objects365.yaml
@@ -386,9 +386,8 @@ names:
 
 # Download script/URL (optional) ---------------------------------------------------------------------------------------
 download: |
-  from tqdm import tqdm
 
-  from utils.general import Path, check_requirements, download, np, xyxy2xywhn
+  from utils.general import Path, check_requirements, download, np, xyxy2xywhn, TQDM
 
   check_requirements('pycocotools>=2.0')
   from pycocotools.coco import COCO
@@ -416,7 +415,7 @@ download: |
           download([f'{url}images/v2/patch{i}.tar.gz' for i in range(16, patches)], dir=images, curl=True, delete=False, threads=8)
 
       # Move
-      for f in tqdm(images.rglob('*.jpg'), desc=f'Moving {split} images'):
+      for f in TQDM(images.rglob('*.jpg'), desc=f'Moving {split} images'):
           f.rename(images / f.name)  # move to /images/{split}
 
       # Labels
@@ -425,7 +424,7 @@ download: |
       for cid, cat in enumerate(names):
           catIds = coco.getCatIds(catNms=[cat])
           imgIds = coco.getImgIds(catIds=catIds)
-          for im in tqdm(coco.loadImgs(imgIds), desc=f'Class {cid + 1}/{len(names)} {cat}'):
+          for im in TQDM(coco.loadImgs(imgIds), desc=f'Class {cid + 1}/{len(names)} {cat}'):
               width, height = im["width"], im["height"]
               path = Path(im["file_name"])  # image filename
               try:

--- a/data/SKU-110K.yaml
+++ b/data/SKU-110K.yaml
@@ -23,8 +23,7 @@ names:
 # Download script/URL (optional) ---------------------------------------------------------------------------------------
 download: |
   import shutil
-  from tqdm import tqdm
-  from utils.general import np, pd, Path, download, xyxy2xywh
+  from utils.general import np, pd, Path, download, xyxy2xywh, TQDM
 
 
   # Download
@@ -46,7 +45,7 @@ download: |
       images, unique_images = x[:, 0], np.unique(x[:, 0])
       with open((dir / d).with_suffix('.txt').__str__().replace('annotations_', ''), 'w') as f:
           f.writelines(f'./images/{s}\n' for s in unique_images)
-      for im in tqdm(unique_images, desc=f'Converting {dir / d}'):
+      for im in TQDM(unique_images, desc=f'Converting {dir / d}'):
           cls = 0  # single-class dataset
           with open((dir / 'labels' / im).with_suffix('.txt'), 'a') as f:
               for r in x[images == im]:

--- a/data/VOC.yaml
+++ b/data/VOC.yaml
@@ -48,9 +48,7 @@ names:
 # Download script/URL (optional) ---------------------------------------------------------------------------------------
 download: |
   import xml.etree.ElementTree as ET
-
-  from tqdm import tqdm
-  from utils.general import download, Path
+  from utils.general import download, Path, TQDM
 
 
   def convert_label(path, lb_path, year, image_id):
@@ -95,7 +93,7 @@ download: |
 
       with open(path / f'VOC{year}/ImageSets/Main/{image_set}.txt') as f:
           image_ids = f.read().strip().split()
-      for id in tqdm(image_ids, desc=f'{image_set}{year}'):
+      for id in TQDM(image_ids, desc=f'{image_set}{year}'):
           f = path / f'VOC{year}/JPEGImages/{id}.jpg'  # old img path
           lb_path = (lbs_path / f.name).with_suffix('.txt')  # new label path
           f.rename(imgs_path / f.name)  # move image

--- a/data/VisDrone.yaml
+++ b/data/VisDrone.yaml
@@ -31,11 +31,10 @@ names:
 
 # Download script/URL (optional) ---------------------------------------------------------------------------------------
 download: |
-  from utils.general import download, os, Path
+  from utils.general import download, os, Path, TQDM
 
   def visdrone2yolo(dir):
       from PIL import Image
-      from tqdm import tqdm
 
       def convert_box(size, box):
           # Convert VisDrone box to YOLO xywh box
@@ -44,7 +43,7 @@ download: |
           return (box[0] + box[2] / 2) * dw, (box[1] + box[3] / 2) * dh, box[2] * dw, box[3] * dh
 
       (dir / 'labels').mkdir(parents=True, exist_ok=True)  # make labels directory
-      pbar = tqdm((dir / 'annotations').glob('*.txt'), desc=f'Converting {dir}')
+      pbar = TQDM((dir / 'annotations').glob('*.txt'), desc=f'Converting {dir}')
       for f in pbar:
           img_size = Image.open((dir / 'images' / f.name).with_suffix('.jpg')).size
           lines = []

--- a/data/xView.yaml
+++ b/data/xView.yaml
@@ -87,10 +87,9 @@ download: |
 
   import numpy as np
   from PIL import Image
-  from tqdm import tqdm
 
   from utils.dataloaders import autosplit
-  from utils.general import download, xyxy2xywhn
+  from utils.general import download, xyxy2xywhn, TQDM
 
 
   def convert_labels(fname=Path('xView/xView_train.geojson')):
@@ -112,7 +111,7 @@ download: |
                            47, 48, 49, -1, 50, 51, -1, 52, -1, -1, -1, 53, 54, -1, 55, -1, -1, 56, -1, 57, -1, 58, 59]
 
       shapes = {}
-      for feature in tqdm(data['features'], desc=f'Converting {fname}'):
+      for feature in TQDM(data['features'], desc=f'Converting {fname}'):
           p = feature['properties']
           if p['bounds_imcoords']:
               id = p['image_id']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,6 @@ classifiers = [
 
 # Required dependencies ------------------------------------------------------------------------------------------------
 dependencies = [
-    "gitpython>=3.1.30", # git repo interaction for training/versioning
     "matplotlib>=3.5.0",
     "numpy>=1.23.5",
     "opencv-python>=4.6.0",
@@ -73,7 +72,6 @@ dependencies = [
     "setuptools>=70.0.0",
     "torch>=1.8.0",
     "torchvision>=0.9.0",
-    "tqdm>=4.66.3", # progress bars
     "psutil>=5.9.0", # system utilization
     "thop>=0.1.1", # FLOPs computation
     "pandas>=1.1.4",

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,11 +3,10 @@
 # Python >= 3.8 recommended
 
 # Base ------------------------------------------------------------------------
-gitpython>=3.1.30            # Git repo interaction for training/versioning
 matplotlib>=3.5.0            # Plotting results and graphs
 numpy>=1.23.5                # Fundamental for array/matrix operations
 opencv-python>=4.6.0         # Image/video processing
-packaging>=20.0             # Version parsing for utils/general.py and loggers
+packaging>=20.0              # Version parsing for loggers
 Pillow>=10.3.0               # Image reading/writing support
 psutil>=5.9.0                # System monitoring (RAM, CPU, etc.)
 PyYAML>=5.3.1                # Reading configs (yaml files)
@@ -16,7 +15,6 @@ scipy>=1.4.1                 # Scientific computing (e.g. IoU, metrics)
 thop>=0.1.1                  # Model profiling - FLOPs and parameter count
 torch>=1.8.0                 # Core PyTorch for training/inference
 torchvision>=0.9.0           # Torch utilities for vision (transforms, datasets)
-tqdm>=4.66.3                 # Progress bar in CLI
 ultralytics>=8.4.83          # YOLO framework library (models, training, utils)
 
 # Logging ---------------------------------------------------------------------

--- a/train.py
+++ b/train.py
@@ -36,7 +36,6 @@ import torch.distributed as dist
 import yaml
 from torch import nn
 from torch.optim import lr_scheduler
-from tqdm import tqdm
 
 FILE = Path(__file__).resolve()
 ROOT = FILE.parents[0]  # YOLOv3 root directory
@@ -57,7 +56,7 @@ from utils.dataloaders import create_dataloader
 from utils.downloads import attempt_download, is_url
 from utils.general import (
     LOGGER,
-    TQDM_BAR_FORMAT,
+    TQDM,
     check_amp,
     check_dataset,
     check_file,
@@ -373,7 +372,7 @@ def train(hyp, opt, device, callbacks):  # hyp is path/to/hyp.yaml or hyp dictio
         pbar = enumerate(train_loader)
         LOGGER.info(("\n" + "%11s" * 7) % ("Epoch", "GPU_mem", "box_loss", "obj_loss", "cls_loss", "Instances", "Size"))
         if RANK in {-1, 0}:
-            pbar = tqdm(pbar, total=nb, bar_format=TQDM_BAR_FORMAT)  # progress bar
+            pbar = TQDM(pbar, total=nb)  # progress bar
         optimizer.zero_grad()
         for i, (imgs, targets, paths, _) in pbar:  # batch -------------------------------------------------------------
             callbacks.run("on_train_batch_start")

--- a/utils/autoanchor.py
+++ b/utils/autoanchor.py
@@ -18,7 +18,7 @@ def check_anchor_order(m):
     a = m.anchors.prod(-1).mean(-1).view(-1)  # mean anchor area per output layer
     da = a[-1] - a[0]  # delta a
     ds = m.stride[-1] - m.stride[0]  # delta s
-    if da and (da.sign() != ds.sign()):  # same order
+    if da and (da.sign() != ds.sign()):  # anchor order does not match stride order
         LOGGER.info(f"{PREFIX}Reversing anchor order")
         m.anchors[:] = m.anchors.flip(0)
 

--- a/utils/autoanchor.py
+++ b/utils/autoanchor.py
@@ -6,10 +6,9 @@ import random
 import numpy as np
 import torch
 import yaml
-from tqdm import tqdm
 
 from utils import TryExcept
-from utils.general import LOGGER, TQDM_BAR_FORMAT, colorstr
+from utils.general import LOGGER, TQDM, colorstr
 
 PREFIX = colorstr("AutoAnchor: ")
 
@@ -147,21 +146,9 @@ def kmean_anchors(dataset="./data/coco128.yaml", n=9, img_size=640, thr=4.0, gen
     wh, wh0 = (torch.tensor(x, dtype=torch.float32) for x in (wh, wh0))
     k = print_results(k, verbose=False)
 
-    # Plot
-    # k, d = [None] * 20, [None] * 20
-    # for i in tqdm(range(1, 21)):
-    #     k[i-1], d[i-1] = kmeans(wh / s, i)  # points, mean distance
-    # fig, ax = plt.subplots(1, 2, figsize=(14, 7), tight_layout=True)
-    # ax = ax.ravel()
-    # ax[0].plot(np.arange(1, 21), np.array(d) ** 2, marker='.')
-    # fig, ax = plt.subplots(1, 2, figsize=(14, 7))  # plot wh
-    # ax[0].hist(wh[wh[:, 0]<100, 0],400)
-    # ax[1].hist(wh[wh[:, 1]<100, 1],400)
-    # fig.savefig('wh.png', dpi=200)
-
     # Evolve
-    f, sh, mp, s = anchor_fitness(k), k.shape, 0.9, 0.1  # fitness, generations, mutation prob, sigma
-    pbar = tqdm(range(gen), bar_format=TQDM_BAR_FORMAT)  # progress bar
+    f, sh, mp, s = anchor_fitness(k), k.shape, 0.9, 0.1  # fitness, anchor shape, mutation prob, sigma
+    pbar = TQDM(range(gen))  # progress bar
     for _ in pbar:
         v = np.ones(sh)
         while (v == 1).all():  # mutate until a change occurs (prevent duplicates)

--- a/utils/dataloaders.py
+++ b/utils/dataloaders.py
@@ -23,7 +23,6 @@ import torch.nn.functional as F
 import yaml
 from PIL import ExifTags, Image, ImageOps
 from torch.utils.data import DataLoader, Dataset, dataloader, distributed
-from tqdm import tqdm
 
 from utils.augmentations import (
     Albumentations,
@@ -37,7 +36,7 @@ from utils.general import (
     DATASETS_DIR,
     LOGGER,
     NUM_THREADS,
-    TQDM_BAR_FORMAT,
+    TQDM,
     check_dataset,
     check_requirements,
     check_yaml,
@@ -555,7 +554,7 @@ class LoadImagesAndLabels(Dataset):
         nf, nm, ne, nc, n = cache.pop("results")  # found, missing, empty, corrupt, total
         if exists and LOCAL_RANK in {-1, 0}:
             d = f"Scanning {cache_path}... {nf} images, {nm + ne} backgrounds, {nc} corrupt"
-            tqdm(None, desc=prefix + d, total=n, initial=n, bar_format=TQDM_BAR_FORMAT)  # display cache results
+            TQDM(None, desc=prefix + d, total=n, initial=n)  # display cache results
             if cache["msgs"]:
                 LOGGER.info("\n".join(cache["msgs"]))  # display warnings
         assert nf > 0 or not augment, f"{prefix}No labels found in {cache_path}, can not start training. {HELP_URL}"
@@ -636,7 +635,7 @@ class LoadImagesAndLabels(Dataset):
             self.im_hw0, self.im_hw = [None] * n, [None] * n
             fcn = self.cache_images_to_disk if cache_images == "disk" else self.load_image
             results = ThreadPool(NUM_THREADS).imap(fcn, range(n))
-            pbar = tqdm(enumerate(results), total=n, bar_format=TQDM_BAR_FORMAT, disable=LOCAL_RANK > 0)
+            pbar = TQDM(enumerate(results), total=n, disable=LOCAL_RANK > 0)
             for i, x in pbar:
                 if cache_images == "disk":
                     b += self.npy_files[i].stat().st_size
@@ -671,11 +670,10 @@ class LoadImagesAndLabels(Dataset):
         nm, nf, ne, nc, msgs = 0, 0, 0, 0, []  # number missing, found, empty, corrupt, messages
         desc = f"{prefix}Scanning {path.parent / path.stem}..."
         with Pool(NUM_THREADS) as pool:
-            pbar = tqdm(
+            pbar = TQDM(
                 pool.imap(verify_image_label, zip(self.im_files, self.label_files, repeat(prefix))),
                 desc=desc,
                 total=len(self.im_files),
-                bar_format=TQDM_BAR_FORMAT,
             )
             for im_file, lb, shape, segments, nm_f, nf_f, ne_f, nc_f, msg in pbar:
                 nm += nm_f
@@ -880,85 +878,6 @@ class LoadImagesAndLabels(Dataset):
 
         return img4, labels4
 
-    def load_mosaic9(self, index):
-        """Loads 1 image + 8 random images into a 9-image mosaic for YOLOv3, returning combined image and labels."""
-        labels9, segments9 = [], []
-        s = self.img_size
-        indices = [index, *random.choices(self.indices, k=8)]  # 8 additional image indices
-        random.shuffle(indices)
-        hp, wp = -1, -1  # height, width previous
-        for i, mosaic_index in enumerate(indices):
-            # Load image
-            img, _, (h, w) = self.load_image(mosaic_index)
-
-            # place img in img9
-            if i == 0:  # center
-                img9 = np.full((s * 3, s * 3, img.shape[2]), 114, dtype=np.uint8)  # base image with 4 tiles
-                h0, w0 = h, w
-                c = s, s, s + w, s + h  # xmin, ymin, xmax, ymax (base) coordinates
-            elif i == 1:  # top
-                c = s, s - h, s + w, s
-            elif i == 2:  # top right
-                c = s + wp, s - h, s + wp + w, s
-            elif i == 3:  # right
-                c = s + w0, s, s + w0 + w, s + h
-            elif i == 4:  # bottom right
-                c = s + w0, s + hp, s + w0 + w, s + hp + h
-            elif i == 5:  # bottom
-                c = s + w0 - w, s + h0, s + w0, s + h0 + h
-            elif i == 6:  # bottom left
-                c = s + w0 - wp - w, s + h0, s + w0 - wp, s + h0 + h
-            elif i == 7:  # left
-                c = s - w, s + h0 - h, s, s + h0
-            elif i == 8:  # top left
-                c = s - w, s + h0 - hp - h, s, s + h0 - hp
-
-            padx, pady = c[:2]
-            x1, y1, x2, y2 = (max(x, 0) for x in c)  # allocate coords
-
-            # Labels
-            labels, segments = self.labels[mosaic_index].copy(), self.segments[mosaic_index].copy()
-            if labels.size:
-                labels[:, 1:] = xywhn2xyxy(labels[:, 1:], w, h, padx, pady)  # normalized xywh to pixel xyxy format
-                segments = [xyn2xy(x, w, h, padx, pady) for x in segments]
-            labels9.append(labels)
-            segments9.extend(segments)
-
-            # Image
-            img9[y1:y2, x1:x2] = img[y1 - pady :, x1 - padx :]  # img9[ymin:ymax, xmin:xmax]
-            hp, wp = h, w  # height, width previous
-
-        # Offset
-        yc, xc = (int(random.uniform(0, s)) for _ in self.mosaic_border)  # mosaic center x, y
-        img9 = img9[yc : yc + 2 * s, xc : xc + 2 * s]
-
-        # Concat/clip labels
-        labels9 = np.concatenate(labels9, 0)
-        labels9[:, [1, 3]] -= xc
-        labels9[:, [2, 4]] -= yc
-        c = np.array([xc, yc])  # centers
-        segments9 = [x - c for x in segments9]
-
-        for x in (labels9[:, 1:], *segments9):
-            np.clip(x, 0, 2 * s, out=x)  # clip when using random_perspective()
-        # img9, labels9 = replicate(img9, labels9)  # replicate
-
-        # Augment
-        img9, labels9, segments9 = copy_paste(img9, labels9, segments9, p=self.hyp["copy_paste"])
-        img9, labels9 = random_perspective(
-            img9,
-            labels9,
-            segments9,
-            degrees=self.hyp["degrees"],
-            translate=self.hyp["translate"],
-            scale=self.hyp["scale"],
-            shear=self.hyp["shear"],
-            perspective=self.hyp["perspective"],
-            border=self.mosaic_border,
-        )  # border to remove
-
-        return img9, labels9
-
     @staticmethod
     def collate_fn(batch):
         """Collates batch of images, labels, paths, and shapes, indexing labels for target image identification."""
@@ -1003,7 +922,7 @@ def flatten_recursive(path=DATASETS_DIR / "coco128"):
     if os.path.exists(new_path):
         shutil.rmtree(new_path)  # delete output folder
     os.makedirs(new_path)  # make new output folder
-    for file in tqdm(glob.glob(f"{Path(path)!s}/**/*.*", recursive=True)):
+    for file in TQDM(glob.glob(f"{Path(path)!s}/**/*.*", recursive=True)):
         shutil.copyfile(file, new_path / Path(file).name)
 
 
@@ -1015,7 +934,7 @@ def extract_boxes(path=DATASETS_DIR / "coco128"):  # from utils.dataloaders impo
     shutil.rmtree(path / "classification") if (path / "classification").is_dir() else None  # remove existing
     files = list(path.rglob("*.*"))
     n = len(files)  # number of files
-    for im_file in tqdm(files, total=n):
+    for im_file in TQDM(files, total=n):
         if im_file.suffix[1:] in IMG_FORMATS:
             # image
             im = cv2.imread(str(im_file))[..., ::-1]  # BGR to RGB
@@ -1064,7 +983,7 @@ def autosplit(path=DATASETS_DIR / "coco128/images", weights=(0.9, 0.1, 0.0), ann
             (path.parent / x).unlink()  # remove existing
 
     print(f"Autosplitting images from {path}" + ", using *.txt labeled images only" * annotated_only)
-    for i, img in tqdm(zip(indices, files), total=n):
+    for i, img in TQDM(zip(indices, files), total=n):
         if not annotated_only or Path(img2label_paths([str(img)])[0]).exists():  # check label
             with open(path.parent / txt[i], "a") as f:
                 f.write(f"./{img.relative_to(path.parent).as_posix()}" + "\n")  # add image to txt file
@@ -1148,7 +1067,7 @@ class HUBDatasetStats:
             raise RuntimeError("error/HUB/dataset_stats/yaml_load") from e
 
         check_dataset(data, autodownload)  # download dataset if missing
-        self.hub_dir = Path(data["path"] + "-hub")
+        self.hub_dir = Path(f"{data['path']}-hub")  # check_dataset() resolves 'path' to a Path
         self.im_dir = self.hub_dir / "images"
         self.im_dir.mkdir(parents=True, exist_ok=True)  # makes /images
         self.stats = {"nc": data["nc"], "names": list(data["names"].values())}  # statistics dictionary
@@ -1199,11 +1118,11 @@ class HUBDatasetStats:
 
     def get_json(self, save=False, verbose=False):
         """Generates dataset JSON for Ultralytics Platform, with optional saving and verbosity; rounds labels to int
-        class and 6 decimal floats.
+        class and 4 decimal floats.
         """
 
         def _round(labels):
-            """Update labels to integer class and 6 decimal place floats."""
+            """Update labels to integer class and 4 decimal place floats."""
             return [[int(c), *(round(x, 4) for x in points)] for c, *points in labels]
 
         for split in "train", "val", "test":
@@ -1214,7 +1133,7 @@ class HUBDatasetStats:
             x = np.array(
                 [
                     np.bincount(label[:, 0].astype(int), minlength=self.data["nc"])
-                    for label in tqdm(dataset.labels, total=dataset.n, desc="Statistics")
+                    for label in TQDM(dataset.labels, total=dataset.n, desc="Statistics")
                 ]
             )  # shape(128x80)
             self.stats[split] = {
@@ -1246,7 +1165,7 @@ class HUBDatasetStats:
                 continue
             dataset = LoadImagesAndLabels(self.data[split])  # load dataset
             desc = f"{split} images"
-            for _ in tqdm(ThreadPool(NUM_THREADS).imap(self._hub_ops, dataset.im_files), total=dataset.n, desc=desc):
+            for _ in TQDM(ThreadPool(NUM_THREADS).imap(self._hub_ops, dataset.im_files), total=dataset.n, desc=desc):
                 pass
         print(f"Done. All images saved to {self.im_dir}")
         return self.im_dir

--- a/utils/general.py
+++ b/utils/general.py
@@ -18,6 +18,7 @@ import sys
 import time
 import urllib
 from copy import deepcopy
+from functools import partial
 from itertools import repeat
 from multiprocessing.pool import ThreadPool
 from pathlib import Path
@@ -31,11 +32,13 @@ import pandas as pd
 import torch
 import torchvision
 import yaml
+from ultralytics.utils import TQDM as _TQDM
 from ultralytics.utils import colorstr
 from ultralytics.utils.checks import check_requirements as check_requirements_ultralytics
 from ultralytics.utils.checks import check_version as check_version_ultralytics
 from ultralytics.utils.files import file_date, file_size  # noqa: F401
 from ultralytics.utils.files import increment_path as increment_path_ultralytics
+from ultralytics.utils.git import GitRepo
 from ultralytics.utils.ops import (  # noqa: F401
     clip_boxes,
     make_divisible,
@@ -60,7 +63,7 @@ NUM_THREADS = min(8, max(1, os.cpu_count() - 1))  # number of YOLOv3 multiproces
 DATASETS_DIR = Path(os.getenv("YOLOv3_DATASETS_DIR", ROOT.parent / "datasets"))  # global datasets directory
 AUTOINSTALL = str(os.getenv("YOLOv3_AUTOINSTALL", "true")).lower() == "true"  # global auto-install mode
 VERBOSE = str(os.getenv("YOLOv3_VERBOSE", "true")).lower() == "true"  # global verbose mode
-TQDM_BAR_FORMAT = "{l_bar}{bar:10}{r_bar}"  # tqdm bar format
+TQDM = partial(_TQDM, file=sys.stderr)  # progress bars on stderr like LOGGER, keeping stdout free for piped output
 FONT = "Arial.ttf"  # https://github.com/ultralytics/assets/releases/download/v0.0.0/Arial.ttf
 
 torch.set_printoptions(linewidth=320, precision=5, profile="long")
@@ -332,7 +335,7 @@ def check_online():
 def git_describe(path=ROOT):  # path must be a directory
     """Returns human-readable git description of a directory if it's a git repository, otherwise an empty string."""
     try:
-        assert (Path(path) / ".git").is_dir()
+        assert (Path(path) / ".git").exists()  # dir in a clone, file in a worktree or submodule
         return check_output(f"git -C {path} describe --tags --long --always", shell=True).decode()[:-1]
     except Exception:
         return ""
@@ -368,26 +371,13 @@ def check_git_status(repo="ultralytics/yolov3", branch="master"):
     LOGGER.info(s)
 
 
-@WorkingDirectory(ROOT)
-def check_git_info(path="."):
-    """Checks YOLOv3 git info (remote, branch, commit) in path, requires 'gitpython'.
-
-    Returns dict.
-    """
-    check_requirements("gitpython")
-    import git
-
-    try:
-        repo = git.Repo(path)
-        remote = repo.remotes.origin.url.replace(".git", "")  # i.e. 'https://github.com/ultralytics/yolov3'
-        commit = repo.head.commit.hexsha  # i.e. '3134699c73af83aac2a481435550b968d5792c0d'
-        try:
-            branch = repo.active_branch.name  # i.e. 'main'
-        except TypeError:  # not on any branch
-            branch = None  # i.e. 'detached HEAD' state
-        return {"remote": remote, "branch": branch, "commit": commit}
-    except git.exc.InvalidGitRepositoryError:  # path is not a git dir
+def check_git_info(path=ROOT):
+    """Checks YOLOv3 git info, returning a dict with remote URL, branch name, and commit hash."""
+    repo = GitRepo(path)
+    if repo.root != Path(path):  # GitRepo searches parents, ignore a repo that merely contains YOLOv3
         return {"remote": None, "branch": None, "commit": None}
+    remote = repo.origin.replace(".git", "") if repo.origin else None  # i.e. 'https://github.com/ultralytics/yolov3'
+    return {"remote": remote, "branch": repo.branch, "commit": repo.commit}  # branch is None on detached HEAD
 
 
 def check_python(minimum="3.8.0"):
@@ -806,12 +796,12 @@ def segment2box(segment, width=640, height=640):
 
 
 def segments2boxes(segments):
-    """Converts segmentation labels to bounding box labels in format (cls, xywh) from (cls, xy1, xy2, ...)."""
+    """Converts segmentation labels to bounding box labels in format (xywh) from (xy1, xy2, ...)."""
     boxes = []
     for s in segments:
         x, y = s.T  # segment xy
-        boxes.append([x.min(), y.min(), x.max(), y.max()])  # cls, xyxy
-    return xyxy2xywh(np.array(boxes))  # cls, xywh
+        boxes.append([x.min(), y.min(), x.max(), y.max()])  # xyxy
+    return xyxy2xywh(np.array(boxes))  # xywh
 
 
 def resample_segments(segments, n=1000):

--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -86,7 +86,7 @@ def torch_distributed_zero_first(local_rank: int):
 # Keep local (do not dedup): YOLOv3 banner plus batch_size divisibility check absent from ultralytics select_device
 def select_device(device="", batch_size=0, newline=True):
     """Selects the device for running models, handling CPU, GPU, and MPS with optional batch size divisibility check."""
-    s = f"YOLOv3 🚀 {git_describe() or file_date()} Python-{platform.python_version()} torch-{torch.__version__} "
+    s = f"YOLOv3 🚀 {git_describe() or file_date(__file__)} Python-{platform.python_version()} torch-{torch.__version__} "
     device = str(device).strip().lower().replace("cuda:", "").replace("none", "")  # to string, 'cuda:0' to '0'
     cpu = device == "cpu"
     mps = device == "mps"  # Apple Metal Performance Shaders (MPS)

--- a/val.py
+++ b/val.py
@@ -28,7 +28,6 @@ from pathlib import Path
 
 import numpy as np
 import torch
-from tqdm import tqdm
 
 FILE = Path(__file__).resolve()
 ROOT = FILE.parents[0]  # YOLOv3 root directory
@@ -41,7 +40,7 @@ from utils.callbacks import Callbacks
 from utils.dataloaders import create_dataloader
 from utils.general import (
     LOGGER,
-    TQDM_BAR_FORMAT,
+    TQDM,
     Profile,
     check_dataset,
     check_img_size,
@@ -148,22 +147,22 @@ def process_batch(detections, labels, iouv):
     """Computes correct prediction matrix for detections against ground truth labels at various IoU thresholds.
 
     Args:
-        detections (np.ndarray): Array of detections with shape (N, 6), where each detection contains [x1, y1, x2, y2,
-            confidence, class].
-        labels (np.ndarray): Array of ground truth labels with shape (M, 5), where each label contains [class, x1, y1,
-            x2, y2].
-        iouv (np.ndarray): Array of IoU thresholds to use for evaluation.
+        detections (torch.Tensor): Tensor of detections with shape (N, 6), where each detection contains [x1, y1, x2,
+            y2, confidence, class].
+        labels (torch.Tensor): Tensor of ground truth labels with shape (M, 5), where each label contains [class, x1,
+            y1, x2, y2].
+        iouv (torch.Tensor): Tensor of IoU thresholds to use for evaluation.
 
     Returns:
-        np.ndarray: Boolean array of shape (N, len(iouv)), indicating correct predictions at each IoU threshold.
+        torch.Tensor: Boolean tensor of shape (N, len(iouv)), indicating correct predictions at each IoU threshold.
 
     Examples:
         ```python
-        detections = np.array([[50, 50, 150, 150, 0.8, 0],
-                               [30, 30, 120, 120, 0.7, 1]])
-        labels = np.array([[0, 50, 50, 150, 150],
-                           [1, 30, 30, 120, 120]])
-        iouv = np.array([0.5, 0.6, 0.7])
+        detections = torch.tensor([[50, 50, 150, 150, 0.8, 0],
+                                   [30, 30, 120, 120, 0.7, 1]])
+        labels = torch.tensor([[0, 50, 50, 150, 150],
+                               [1, 30, 30, 120, 120]])
+        iouv = torch.tensor([0.5, 0.6, 0.7])
 
         correct = process_batch(detections, labels, iouv)
         ```
@@ -348,7 +347,7 @@ def run(
     loss = torch.zeros(3, device=device)
     jdict, stats, ap, ap_class = [], [], [], []
     callbacks.run("on_val_start")
-    pbar = tqdm(dataloader, desc=s, bar_format=TQDM_BAR_FORMAT)  # progress bar
+    pbar = TQDM(dataloader, desc=s)  # progress bar
     for batch_i, (im, targets, paths, shapes) in enumerate(pbar):
         callbacks.run("on_val_batch_start")
         with dt[0]:


### PR DESCRIPTION
Mirrors ultralytics/yolov5#13824 for YOLOv3. Drops the `tqdm` and `gitpython` dependencies in favour of the natives already shipped by the `ultralytics` package we depend on (floor `>=8.4.83`; `TQDM` landed in 8.3.186, `GitRepo` in 8.3.191). Net **-121 lines**.

### Migration

- **`tqdm` → `ultralytics.utils.TQDM`.** `utils/general.py` now exports `TQDM = partial(_TQDM, file=sys.stderr)` in the slot `TQDM_BAR_FORMAT` used to occupy, so every consumer swaps one name in its existing import tuple. The `file=sys.stderr` is load-bearing: `tqdm` defaults to stderr but ultralytics `TQDM` defaults to stdout, which would have split bars away from `LOGGER` and into anything piping stdout. `TQDM` ignores `bar_format`, so `TQDM_BAR_FORMAT` and all its call-site kwargs are deleted.
- **`gitpython` → `ultralytics.utils.git.GitRepo`.** `check_git_info()` drops from 17 lines to 6, plus its `check_requirements("gitpython")` self-install and `@WorkingDirectory(ROOT)` decorator. `GitRepo` searches parent directories where `git.Repo()` did not, so the root is pinned to `ROOT` to keep an enclosing repo's remote/branch/commit out of saved checkpoints.
- Dataset download scripts in `data/*.yaml` migrated too, so the trimmed `requirements.txt` stays sufficient.

### Fixes riding along

- `utils/torch_utils.py` — the startup banner called `file_date()` with no argument. Since `file_date` became a re-export of the ultralytics helper, its default bound to the *ultralytics* module file, so any non-git install advertised a third-party package's mtime as the YOLOv3 version. Now `file_date(__file__)`.
- `utils/dataloaders.py` — deleted `load_mosaic9()` (78 lines), unreferenced anywhere in the repo and already removed from YOLOv5.
- `utils/dataloaders.py` — `HUBDatasetStats` raised `TypeError` on `data["path"] + "-hub"`; `check_dataset()` resolves `path` to a `Path`.
- `utils/general.py` — `git_describe()` asserted `.git` **is a directory**, returning `""` inside a worktree or submodule where it is a file.
- `benchmarks.py` — dropped the `notebook_init()` calls, which `pip uninstall -y wandb` from the user's environment mid-benchmark.
- Docstring/comment corrections: `segments2boxes` never touched a class column; `val.py::process_batch` documents `np.ndarray` but takes and returns torch tensors; `get_json`/`_round` claimed 6 decimal places while the code rounds to 4; `kmean_anchors` labelled `k.shape` as "generations"; `requirements.txt` credited `packaging` to `utils/general.py`, which does not import it. Deleted a dead commented-out plotting block in `utils/autoanchor.py`.

### Validation

`ruff format` clean and `ruff check` down one error from master. Full CI smoke matrix run locally on CPU with `yolov3-tiny`: `train`, `val`, `detect`, `export --include torchscript`, `benchmarks --pt-only`, plus a check that progress bars stay on stderr.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Modernizes YOLOv3’s utilities by adopting Ultralytics shared components, simplifying dependencies, and standardizing progress bars across training, validation, and dataset tools. 🚀

### 📊 Key Changes
- Replaced direct `tqdm` usage with Ultralytics’ shared `TQDM` utility, including progress output directed to stderr.
- Removed unused `gitpython` and `tqdm` dependencies from `pyproject.toml` and `requirements.txt`.
- Reworked Git metadata detection to use Ultralytics’ `GitRepo`, with improved support for worktrees and submodules.
- Updated dataset download and conversion scripts for Argoverse, Objects365, SKU-110K, VOC, VisDrone, and xView to use the shared progress-bar implementation.
- Removed the unused nine-image mosaic augmentation method from the dataloader.
- Removed redundant system-information logging from benchmark and export commands.
- Updated dataset path handling and reduced dataset JSON coordinate rounding from six to four decimal places.
- Corrected documentation and type descriptions in validation and label-conversion utilities.

### 🎯 Purpose & Impact
- 📦 Reduces dependency overhead and keeps YOLOv3 aligned with current Ultralytics infrastructure.
- 🖥️ Produces more consistent, cleaner progress output, especially when logs are redirected or piped.
- 🔧 Improves Git version detection in cloned repositories, worktrees, and submodules.
- 🧹 Simplifies maintenance by removing obsolete code and unused augmentation functionality.
- 📉 May slightly reduce precision in exported dataset JSON coordinates because values are now rounded to four decimal places.
- ⚠️ Users relying on the removed `load_mosaic9()` method or directly importing removed progress-bar constants may need to update their code.