### PR TITLE
Log dataset cache scan line instead of a throwaway progress bar

### DIFF
--- a/utils/dataloaders.py
+++ b/utils/dataloaders.py
@@ -556,7 +556,7 @@ class LoadImagesAndLabels(Dataset):
         nf, nm, ne, nc, n = cache.pop("results")  # found, missing, empty, corrupt, total
         if exists and LOCAL_RANK in {-1, 0}:
             d = f"Scanning {cache_path}... {nf} images, {nm + ne} backgrounds, {nc} corrupt"
-            TQDM(None, desc=prefix + d, total=n, initial=n)  # display cache results
+            LOGGER.info(prefix + d)  # display cache results
             if cache["msgs"]:
                 LOGGER.info("\n".join(cache["msgs"]))  # display warnings
         assert nf > 0 or not augment, f"{prefix}No labels found in {cache_path}, can not start training. {HELP_URL}"


### PR DESCRIPTION
Follow-up to #2452. The dataset cache-hit line was silently lost in non-interactive consoles.

`TQDM(None, desc=..., total=n, initial=n)` was a throwaway bar built only for its constructor's side effect — it is never iterated and never explicitly closed. That worked under `tqdm`, but ultralytics `TQDM` renders nothing for it in non-interactive environments:

- `__init__` gates its render on `not self.noninteractive`, and `is_noninteractive_console()` is true whenever `GITHUB_ACTIONS` or `RUNPOD_POD_ID` is set.
- `close()` (reached via `__del__`) then skips the final render too, because `initial == total` leaves `n == last_print_n`.

The result is a bare newline where the line used to be. Reproduced on master:

```console
$ GITHUB_ACTIONS=true python -c "from utils.general import TQDM; TQDM(None, desc='Scanning cache... 126 images, 2 backgrounds, 0 corrupt', total=128, initial=128)" | od -c
0000000  \n
```

That path is `if exists and LOCAL_RANK in {-1, 0}` — every cache hit — so it affects this repo's own CI logs and RunPod training.

Replaced with `LOGGER.info(prefix + d)`, which deletes the bar object rather than working around it. `LOGGER` is already imported here, already routes to stderr (the same stream the progress bars use), and renders identically in terminals, GitHub Actions and RunPod. The other `TQDM` call sites are unaffected: each wraps a real iterable, so `close()` renders a final line because `n != last_print_n`.

Verified with a cache-hit train run under both `GITHUB_ACTIONS=true` and an interactive TTY; the line is present in both. `ruff format`/`ruff check` clean.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Replaced the dataset cache progress bar with a simpler log message when loading cached image and label information. 📋

### 📊 Key Changes

- Updated `utils/dataloaders.py` to use `LOGGER.info()` instead of `TQDM` for cache scan results.
- Cache statistics, including found, missing, background, and corrupt images, are still reported.
- Existing cache warning messages continue to be logged unchanged.

### 🎯 Purpose & Impact

- Simplifies console output when cached datasets are loaded. ✨
- Avoids displaying a completed progress bar for an operation that has already finished.
- Maintains the same dataset validation and warning behavior, with no expected impact on training functionality.