### PR TITLE
Honor --opset on ONNX export

### DIFF
--- a/export.py
+++ b/export.py
@@ -217,6 +217,7 @@ def export_onnx(model, im, file, opset, dynamic, simplify, prefix=colorstr("ONNX
     """
     check_requirements("onnx>=1.12.0")
     import onnx
+    from ultralytics.utils.export import torch2onnx
 
     LOGGER.info(f"\n{prefix} starting export with onnx {onnx.__version__}...")
     f = file.with_suffix(".onnx")
@@ -226,16 +227,14 @@ def export_onnx(model, im, file, opset, dynamic, simplify, prefix=colorstr("ONNX
         dynamic = {"images": {0: "batch", 2: "height", 3: "width"}}  # shape(1,3,640,640)
         dynamic["output0"] = {0: "batch", 1: "anchors"}  # shape(1,25200,85)
 
-    torch.onnx.export(
+    torch2onnx(
         model.cpu() if dynamic else model,  # --dynamic only compatible with cpu
         im.cpu() if dynamic else im,
         f,
-        verbose=False,
-        opset_version=opset,
-        do_constant_folding=True,  # WARNING: DNN inference with torch>=1.12 may require do_constant_folding=False
+        opset=opset,
         input_names=["images"],
         output_names=output_names,
-        dynamic_axes=dynamic or None,
+        dynamic=dynamic or None,
     )
 
     # Checks


### PR DESCRIPTION
Companion to ultralytics/yolov5#13830.

`torch.onnx.export` defaults `dynamo=True` on torch ≥2.6. The dynamo path exports at opset 18 regardless of what was requested, attempts a downgrade, fails, and writes the opset-18 file anyway.

Reproduced on torch 2.13 / onnx 1.18 with `--opset 12`:

```
W torch/onnx/_internal/exporter/_compat.py:133] Setting ONNX exporter to use operator set
  version 18 because the requested opset_version 12 is a lower version ...
Failed to convert the model to the target version 12 using the ONNX C API. The model was not modified
```
```python
>>> onnx.load("yolov3-tiny.onnx").opset_import
[domain: "" version: 18]        # requested 12
```

`ultralytics.utils.export.torch2onnx` wraps the identical `torch.onnx.export` call with `dynamo=False` on `TORCH_2_4+`, so the local call is **replaced rather than re-implemented**. Every argument maps 1:1 (`dynamic_axes` → `dynamic`, `opset_version` → `opset`); `do_constant_folding=True` and `verbose=False` are already its defaults.

### Numerics unchanged

`val.py --data coco128.yaml --img 320 --device cpu`:

| model | P | R | mAP50 | mAP50-95 |
|---|---|---|---|---|
| master export (opset 18) | 0.478 | 0.379 | 0.393 | 0.227 |
| this PR (opset 12) | 0.478 | 0.379 | 0.393 | 0.227 |

### Notes

- **Import is function-scoped.** `models/common.py` imports this module on every `DetectMultiBackend` construction, so a module-level import would add 58 modules to every `detect.py` / `val.py` / `benchmarks.py` run.
- Unlike yolov5, this repo does not list `onnxscript` in `check_requirements`, so there is nothing to drop here.

### Validation

Both at `--opset 12`, both writing opset 12:

- default → export success, val metrics above
- `--dynamic` → success, batch dim preserved as `batch`
- `ruff format` + `ruff check` → clean

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updated YOLOv3 ONNX export to use Ultralytics’ shared `torch2onnx` utility for more consistent and maintainable conversion. 🔄

### 📊 Key Changes

- Replaced the direct `torch.onnx.export` call with `ultralytics.utils.export.torch2onnx`.
- Passed the ONNX opset, input/output names, and dynamic shape settings through the shared utility.
- Removed direct handling of verbose output and constant folding options from `export.py`.
- Preserved support for dynamic batch, height, width, and output anchor dimensions.

### 🎯 Purpose & Impact

- ✅ Standardizes ONNX export behavior with other Ultralytics tools.
- 🛠️ Centralizes export logic, making future compatibility improvements easier.
- 📦 Keeps existing dynamic-shape export functionality for flexible inference deployments.
- 🚀 May improve consistency across PyTorch and ONNX export workflows while reducing duplicated code.