### PR TITLE
Backport three correctness fixes from yolov5

### DIFF
--- a/utils/augmentations.py
+++ b/utils/augmentations.py
@@ -22,16 +22,21 @@ class Albumentations:
             import albumentations as A
 
             check_version(A.__version__, "1.0.3", hard=True)  # version requirement
+            v2 = check_version(A.__version__, "2.0.0")  # Albumentations 2.x renamed several constructor arguments
 
             T = [
-                A.RandomResizedCrop(height=size, width=size, scale=(0.8, 1.0), ratio=(0.9, 1.11), p=0.0),
+                A.RandomResizedCrop(size=(size, size), scale=(0.8, 1.0), ratio=(0.9, 1.11), p=0.0)
+                if v2
+                else A.RandomResizedCrop(height=size, width=size, scale=(0.8, 1.0), ratio=(0.9, 1.11), p=0.0),
                 A.Blur(p=0.01),
                 A.MedianBlur(p=0.01),
                 A.ToGray(p=0.01),
                 A.CLAHE(p=0.01),
                 A.RandomBrightnessContrast(p=0.0),
                 A.RandomGamma(p=0.0),
-                A.ImageCompression(quality_lower=75, p=0.0),
+                A.ImageCompression(quality_range=(75, 100), p=0.0)
+                if v2
+                else A.ImageCompression(quality_lower=75, p=0.0),
             ]  # transforms
             self.transform = A.Compose(T, bbox_params=A.BboxParams(format="yolo", label_fields=["class_labels"]))
 

--- a/utils/downloads.py
+++ b/utils/downloads.py
@@ -23,7 +23,7 @@ def is_url(url, check=True):
 
 def gsutil_getsize(url=""):
     """Returns the size of a file at a 'gs://' URL using gsutil du command; 0 if file not found or command fails."""
-    output = subprocess.check_output(["gsutil", "du", url], shell=True, encoding="utf-8")
+    output = subprocess.check_output(["gsutil", "du", url], encoding="utf-8")
     return int(output.split()[0]) if output else 0
 
 

--- a/utils/plots.py
+++ b/utils/plots.py
@@ -15,7 +15,7 @@ import pandas as pd
 import seaborn as sn
 import torch
 from PIL import Image, ImageDraw
-from scipy.ndimage.filters import gaussian_filter1d
+from scipy.ndimage import gaussian_filter1d
 from ultralytics.utils.plotting import Annotator
 
 from utils import TryExcept, threaded


### PR DESCRIPTION
Three bugs this repo carries that yolov5 has already fixed. Each is independently reproducible.

### 1. Albumentations is silently disabled on albumentations ≥2.0

Albumentations 2.0 renamed `RandomResizedCrop(height=, width=)` → `size=` and `ImageCompression(quality_lower=)` → `quality_range=`. The bare `except Exception` at `utils/augmentations.py:44` swallows the constructor error, so `self.transform` stays `None` and training proceeds with **no albumentations augmentation at all** — no warning, no traceback.

Reproduced on the installed albumentations 2.0.8:

```
# master
Field required [type=missing, input_value={'scale': (0.8, 1.0), ...}]
  transform built: False          ← augmentation silently off

# this PR
albumentations: Blur(p=0.01, ...), MedianBlur(p=0.01, ...), ToGray(p=0.01, ...), CLAHE(p=0.01, ...)
  transform built: True
```

Fixed by gating the two constructors on the installed version, identical to yolov5 `utils/augmentations.py:30-44`. This is the one change in this PR that adds lines (+5) — the arguments genuinely differ between 1.x and 2.x and both must remain supported, since `requirements.txt` floors at `albumentations>=1.0.3`.

### 2. `gsutil_getsize` always returns 0

```python
subprocess.check_output(["gsutil", "du", url], shell=True, encoding="utf-8")
```

A list argv combined with `shell=True` makes POSIX run `/bin/sh -c gsutil` with `du` and the URL bound to `$0`/`$1` — they never reach the command. Demonstrated with a harmless substitute:

```python
>>> subprocess.check_output(["echo", "du", "gs://bucket/file"], shell=True, encoding="utf-8")
'\n'                                 # arguments dropped
>>> subprocess.check_output(["echo", "du", "gs://bucket/file"], encoding="utf-8")
'du gs://bucket/file\n'              # correct
```

The empty output makes the function return `0` unconditionally, which silently disables the evolve bucket sync at `utils/general.py:1018` (`if gsutil_getsize(url) > local_size` is never true). yolov5 dropped `shell=True` already.

### 3. `scipy.ndimage.filters` is a deprecated alias

`from scipy.ndimage.filters import gaussian_filter1d` still resolves today but the namespace is slated for removal in SciPy 2.0. yolov5 imports from `scipy.ndimage` directly.

### Validation

- `python train.py --imgsz 64 --batch 32 --weights yolov3-tiny.pt --cfg yolov3-tiny.yaml --epochs 1 --device cpu` → completes, and now prints the `albumentations:` banner listing active transforms (it printed nothing before)
- `utils.plots` imports cleanly
- `ruff format` + `ruff check` → clean

### Deliberately not included

`models/experimental.py:134` uses a bare `print()` where yolov5 uses `LOGGER.info`. Fixing it means adding a `LOGGER` import to this module for a purely cosmetic gain, so it is left out of a bug-fix PR.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Improves compatibility with newer dependencies and modernizes utility imports and subprocess usage. 🛠️

### 📊 Key Changes

- Added support for **Albumentations 2.x** by adapting renamed arguments for:
  - `RandomResizedCrop`
  - `ImageCompression`
- Preserved compatibility with older Albumentations versions through version-aware configuration.
- Removed the deprecated `scipy.ndimage.filters` import path in favor of `scipy.ndimage`.
- Simplified the `gsutil` subprocess call by removing `shell=True`.

### 🎯 Purpose & Impact

- Enables YOLOv3 users to run image augmentations with both Albumentations 1.x and 2.x. ✅
- Reduces dependency-related errors when installing or upgrading packages.
- Uses a safer and cleaner subprocess invocation for Google Cloud Storage file-size checks. 🔒
- Prevents warnings or future breakage caused by deprecated SciPy import paths. 📦