### PR TITLE
Fix EarlyStopping never triggering on a fitness plateau

### DIFF
--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -306,7 +306,7 @@ class EarlyStopping:
 
     def __call__(self, epoch, fitness):
         """Updates stopping criteria based on fitness; returns True to stop if no improvement in 'patience' epochs."""
-        if fitness >= self.best_fitness:  # >= 0 to allow for early zero-fitness stage of training
+        if fitness > self.best_fitness or self.best_fitness == 0:  # allow for early zero-fitness stage of training
             self.best_epoch = epoch
             self.best_fitness = fitness
         delta = epoch - self.best_epoch  # epochs without improvement


### PR DESCRIPTION
`EarlyStopping.__call__` treated an unchanged fitness as an improvement:

```python
if fitness >= self.best_fitness:   # >= resets best_epoch every epoch
    self.best_epoch = epoch
    self.best_fitness = fitness
```

`best_epoch` was reset on every epoch where fitness merely held steady, so `delta = epoch - self.best_epoch` never grew and `--patience` could never elapse **on a plateau** — precisely the scenario EarlyStopping exists to catch.

### Why not a bare `>`

The obvious one-character fix is wrong. The original `>=` comment ("allow for early zero-fitness stage of training") was guarding something real: early epochs commonly report fitness `0.0`, and under a strict `>` those never update `best_epoch`, so training gets killed during warmup.

Measured across candidate predicates at `patience=3` (value = epoch training stops at, `None` = runs to completion):

| fitness curve | `>=` (before) | bare `>` | `> or best == 0` (this PR) |
|---|---|---|---|
| flat 0.5 × 12 | **never stops** | 3 | 3 |
| zero warmup ×5, then rising | never stops | **stops at 3** ❌ | never stops ✅ |
| rising then plateau | **never stops** ❌ | 6 | 6 |
| normal improving | never stops ✅ | never stops ✅ | never stops ✅ |
| all zeros | never stops | **stops at 3** ❌ | never stops ✅ |

Only `fitness > self.best_fitness or self.best_fitness == 0` is correct in every column. This matches `ultralytics.utils.torch_utils.EarlyStopping`.

### Scope

One line. The class is **not** replaced with the ultralytics one: that would also swap the log message to `i.e. \`patience=300\``, which is wrong guidance for a CLI-driven repo where the flag is `python train.py --patience 300`. Deduplicating this class is a separate question from fixing the predicate, and bundling them would hide a behavior change inside a refactor.

### Impact

Runs that plateau will now stop after `--patience` epochs instead of training to `--epochs`. That is the documented intent of the flag. Anyone relying on the old behavior to always train the full schedule should pass `--patience 0`, which disables EarlyStopping.

### Validation

- All five curves above reproduced against the patched class in-repo
- Smoke train completes: `--imgsz 64 --batch 32 --epochs 1 --device cpu`
- `ruff format` + `ruff check` → clean

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Improves early-stopping behavior so training can progress correctly when fitness remains at zero early on. 🚀

### 📊 Key Changes

- Updated the `EarlyStopping` fitness check in `utils/torch_utils.py`.
- Fitness now counts as an improvement when it is greater than the previous best, or when the best fitness is still zero.
- Replaced the previous `>=` comparison with more precise logic.

### 🎯 Purpose & Impact

- Prevents repeated zero-fitness results from continually resetting the early-stopping timer.
- Allows training to stop sooner when there is no meaningful improvement.
- Preserves flexibility during the initial stage of training, when zero fitness may be expected. ⏱️