### PR TITLE
Count an all-zero fitness plateau as no improvement

### DIFF
--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -299,14 +299,14 @@ class EarlyStopping:
         """Initializes EarlyStopping to monitor training, halting if no improvement in 'patience' epochs, defaulting to
         30.
         """
-        self.best_fitness = 0.0  # i.e. mAP
+        self.best_fitness = -1.0  # below any valid fitness so the first epoch always sets the baseline
         self.best_epoch = 0
         self.patience = patience or float("inf")  # epochs to wait after fitness stops improving to stop
         self.possible_stop = False  # possible stop may occur next epoch
 
     def __call__(self, epoch, fitness):
         """Updates stopping criteria based on fitness; returns True to stop if no improvement in 'patience' epochs."""
-        if fitness > self.best_fitness or self.best_fitness == 0:  # allow for early zero-fitness stage of training
+        if fitness > self.best_fitness:  # only a strict improvement resets the patience counter
             self.best_epoch = epoch
             self.best_fitness = fitness
         delta = epoch - self.best_epoch  # epochs without improvement


### PR DESCRIPTION
Follow-up to #2458. That PR fixed the plateau case for positive fitness but kept `or self.best_fitness == 0`, which left one case unfixed — the same finding the automated reviewer raised on the yolov5 counterpart (ultralytics/yolov5#13833).

### The remaining hole

`self.best_fitness` starts at `0.0`, so for a run whose fitness never leaves zero the right-hand clause fires on **every** epoch, resetting `best_epoch` each time. `delta` never grows and patience never elapses. Both detection and segmentation fitness are weighted sums of mAP metrics, so an all-zero curve is a genuine plateau — a model learning nothing trains the full schedule instead of stopping.

### Fix

Initialize the baseline below any valid fitness so the first epoch sets it unconditionally, and require a strict improvement thereafter:

```python
self.best_fitness = -1.0   # below any valid fitness so the first epoch always sets the baseline
...
if fitness > self.best_fitness:   # only a strict improvement resets the patience counter
```

This drops the special case entirely rather than adding another branch.

### Behavior, at the real default `--patience 100`

| fitness curve | #2458 (current) | this PR |
|---|---|---|
| flat 0.5 | 100 | 100 |
| zero warmup ×5, then rising | never stops | never stops |
| rising then plateau | 103 | 103 |
| normal improving | never stops | never stops |
| **all zeros** | **never stops** ❌ | **100** ✅ |

Only the all-zero row changes. Warmup is unaffected: a handful of zero-fitness epochs is nowhere near the 100-epoch default, and a run that is still at zero after 100 epochs is not warming up.

(Checking at an artificially small `--patience 3` shows the zero-warmup curve stopping at 3 — correct, since that is what a patience of 3 asks for.)

### Validation

- All five curves above reproduced against the patched class at both `patience=3` and `patience=100`
- Smoke train completes: `--imgsz 64 --batch 32 --epochs 1 --device cpu`
- `ruff format` + `ruff check` → clean

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves early stopping by ensuring the first training epoch always establishes a valid fitness baseline and only genuine improvements reset patience.

### 📊 Key Changes
- Initializes `best_fitness` to `-1.0` instead of `0.0`.
- Removes the special-case logic that treated zero fitness as an improvement.
- Requires fitness to strictly exceed the current best value before resetting the early-stopping counter.

### 🎯 Purpose & Impact
- 🛑 Makes early stopping behavior more consistent and predictable, especially during training epochs with zero fitness.
- 📈 Prevents repeated zero-fitness results from incorrectly resetting the patience period.
- ⚙️ Ensures the first epoch is recorded as the baseline, allowing training to stop appropriately when fitness does not improve.