### PR TITLE
Delete unreachable code across utils, loggers and models

### DIFF
--- a/models/experimental.py
+++ b/models/experimental.py
@@ -9,6 +9,7 @@ from torch import nn
 from ultralytics.utils.patches import torch_load
 
 from utils.downloads import attempt_download
+from utils.general import LOGGER
 
 
 class Sum(nn.Module):
@@ -73,10 +74,6 @@ class MixConv2d(nn.Module):
 class Ensemble(nn.ModuleList):
     """Combines outputs from multiple models to improve inference results."""
 
-    def __init__(self):
-        """Initializes an ensemble of models to combine their outputs."""
-        super().__init__()
-
     def forward(self, x, augment=False, profile=False, visualize=False):
         """Applies ensemble of models on input `x`, with options for augmentation, profiling, and visualization,
         returning inference outputs.
@@ -131,7 +128,7 @@ def attempt_load(weights, device=None, inplace=True, fuse=True):
         return model[-1]
 
     # Return detection ensemble
-    print(f"Ensemble created with {weights}\n")
+    LOGGER.info(f"Ensemble created with {weights}\n")
     for k in "names", "nc", "yaml":
         setattr(model, k, getattr(model[0], k))
     model.stride = model[torch.argmax(torch.tensor([m.stride.max() for m in model])).int()].stride  # max stride

--- a/train.py
+++ b/train.py
@@ -246,7 +246,7 @@ def train(hyp, opt, device, callbacks):  # hyp is path/to/hyp.yaml or hyp dictio
             """Linear learning rate scheduler function with decay calculated by epoch proportion."""
             return (1 - x / epochs) * (1.0 - hyp["lrf"]) + hyp["lrf"]  # linear
 
-    scheduler = lr_scheduler.LambdaLR(optimizer, lr_lambda=lf)  # plot_lr_scheduler(optimizer, scheduler, epochs)
+    scheduler = lr_scheduler.LambdaLR(optimizer, lr_lambda=lf)
 
     # EMA
     ema = ModelEMA(model) if RANK in {-1, 0} else None

--- a/utils/callbacks.py
+++ b/utils/callbacks.py
@@ -44,14 +44,6 @@ class Callbacks:
         assert callable(callback), f"callback '{callback}' is not callable"
         self._callbacks[hook].append({"name": name, "callback": callback})
 
-    def get_registered_actions(self, hook=None):
-        """Returns all the registered actions by callback hook.
-
-        Args:
-            hook: The name of the hook to check, defaults to all
-        """
-        return self._callbacks[hook] if hook else self._callbacks
-
     def run(self, hook, *args, thread=False, **kwargs):
         """Loop through the registered actions and fire all callbacks on main thread.
 

--- a/utils/dataloaders.py
+++ b/utils/dataloaders.py
@@ -4,11 +4,9 @@
 import contextlib
 import glob
 import hashlib
-import json
 import math
 import os
 import random
-import shutil
 import time
 from itertools import repeat
 from multiprocessing.pool import Pool, ThreadPool
@@ -20,7 +18,6 @@ import numpy as np
 import psutil
 import torch
 import torch.nn.functional as F
-import yaml
 from PIL import ExifTags, Image, ImageOps
 from torch.utils.data import DataLoader, Dataset, dataloader, distributed
 
@@ -37,17 +34,13 @@ from utils.general import (
     LOGGER,
     NUM_THREADS,
     TQDM,
-    check_dataset,
     check_requirements,
-    check_yaml,
     clean_str,
     cv2,
     is_colab,
     is_kaggle,
     segments2boxes,
-    unzip_file,
     xyn2xy,
-    xywh2xyxy,
     xywhn2xyxy,
     xyxy2xywhn,
 )
@@ -917,52 +910,6 @@ class LoadImagesAndLabels(Dataset):
 
 
 # Ancillary functions --------------------------------------------------------------------------------------------------
-def flatten_recursive(path=DATASETS_DIR / "coco128"):
-    """Flattens a directory recursively by copying all files to a new top-level directory, given an input path."""
-    new_path = Path(f"{path!s}_flat")
-    if os.path.exists(new_path):
-        shutil.rmtree(new_path)  # delete output folder
-    os.makedirs(new_path)  # make new output folder
-    for file in TQDM(glob.glob(f"{Path(path)!s}/**/*.*", recursive=True)):
-        shutil.copyfile(file, new_path / Path(file).name)
-
-
-def extract_boxes(path=DATASETS_DIR / "coco128"):  # from utils.dataloaders import *; extract_boxes()
-    """Converts detection dataset to classification dataset, creating one directory per class with images cropped to
-    bounding boxes.
-    """
-    path = Path(path)  # images dir
-    shutil.rmtree(path / "classification") if (path / "classification").is_dir() else None  # remove existing
-    files = list(path.rglob("*.*"))
-    n = len(files)  # number of files
-    for im_file in TQDM(files, total=n):
-        if im_file.suffix[1:] in IMG_FORMATS:
-            # image
-            im = cv2.imread(str(im_file))[..., ::-1]  # BGR to RGB
-            h, w = im.shape[:2]
-
-            # labels
-            lb_file = Path(img2label_paths([str(im_file)])[0])
-            if Path(lb_file).exists():
-                with open(lb_file) as f:
-                    lb = np.array([x.split() for x in f.read().strip().splitlines()], dtype=np.float32)  # labels
-
-                for j, x in enumerate(lb):
-                    c = int(x[0])  # class
-                    f = (path / "classification") / f"{c}" / f"{path.stem}_{im_file.stem}_{j}.jpg"  # new filename
-                    if not f.parent.is_dir():
-                        f.parent.mkdir(parents=True)
-
-                    b = x[1:] * [w, h, w, h]  # box
-                    # b[2:] = b[2:].max()  # rectangle to square
-                    b[2:] = b[2:] * 1.2 + 3  # pad
-                    b = xywh2xyxy(b.reshape(-1, 4)).ravel().astype(int)
-
-                    b[[0, 2]] = np.clip(b[[0, 2]], 0, w)  # clip boxes outside of image
-                    b[[1, 3]] = np.clip(b[[1, 3]], 0, h)
-                    assert cv2.imwrite(str(f), im[b[1] : b[3], b[0] : b[2]]), f"box failure in {f}"
-
-
 def autosplit(path=DATASETS_DIR / "coco128/images", weights=(0.9, 0.1, 0.0), annotated_only=False):
     """Autosplit a dataset into train/val/test splits and save path/autosplit_*.txt files Usage: from utils.dataloaders
     import *; autosplit().
@@ -1039,134 +986,3 @@ def verify_image_label(args):
         nc = 1
         msg = f"{prefix}WARNING ⚠️ {im_file}: ignoring corrupt image/label: {e}"
         return [None, None, None, None, nm, nf, ne, nc, msg]
-
-
-class HUBDatasetStats:
-    """Generate dataset statistics JSON and a `-hub` directory of downscaled images for the Ultralytics Platform.
-
-    Args:
-        path (str): Path to data.yaml, or data.zip with data.yaml inside.
-        autodownload (bool): Attempt to download the dataset if not found locally.
-
-    Examples:
-        >>> from utils.dataloaders import HUBDatasetStats
-        >>> stats = HUBDatasetStats("coco128.yaml", autodownload=True)  # from a data.yaml
-        >>> stats = HUBDatasetStats("path/to/coco128.zip")  # from a data.zip
-        >>> stats.get_json(save=False)
-        >>> stats.process_images()
-    """
-
-    def __init__(self, path="coco128.yaml", autodownload=False):
-        """Initializes HUBDatasetStats with dataset path, optionally autodownloads; supports .yaml or .zip formats."""
-        zipped, data_dir, yaml_path = self._unzip(Path(path))
-        try:
-            with open(check_yaml(yaml_path), errors="ignore") as f:
-                data = yaml.safe_load(f)  # data dict
-                if zipped:
-                    data["path"] = data_dir
-        except Exception as e:
-            raise RuntimeError("error/HUB/dataset_stats/yaml_load") from e
-
-        check_dataset(data, autodownload)  # download dataset if missing
-        self.hub_dir = Path(f"{data['path']}-hub")  # check_dataset() resolves 'path' to a Path
-        self.im_dir = self.hub_dir / "images"
-        self.im_dir.mkdir(parents=True, exist_ok=True)  # makes /images
-        self.stats = {"nc": data["nc"], "names": list(data["names"].values())}  # statistics dictionary
-        self.data = data
-
-    @staticmethod
-    def _find_yaml(dir):
-        """Finds a single `data.yaml` file within specified directory, preferring matches to directory name."""
-        files = list(dir.glob("*.yaml")) or list(dir.rglob("*.yaml"))  # try root level first and then recursive
-        assert files, f"No *.yaml file found in {dir}"
-        if len(files) > 1:
-            files = [f for f in files if f.stem == dir.stem]  # prefer *.yaml files that match dir name
-            assert files, f"Multiple *.yaml files found in {dir}, only 1 *.yaml file allowed"
-        assert len(files) == 1, f"Multiple *.yaml files found: {files}, only 1 *.yaml file allowed in {dir}"
-        return files[0]
-
-    def _unzip(self, path):
-        """Unzips a .zip file, verifying its integrity and locating the associated YAML file within the unzipped
-        directory.
-        """
-        if not str(path).endswith(".zip"):  # path is data.yaml
-            return False, None, path
-        assert Path(path).is_file(), f"Error unzipping {path}, file not found"
-        unzip_file(path, path=path.parent)
-        dir = path.with_suffix("")  # dataset directory == zip name
-        assert dir.is_dir(), f"Error unzipping {path}, {dir} not found. path/to/abc.zip MUST unzip to path/to/abc/"
-        return True, str(dir), self._find_yaml(dir)  # zipped, data_dir, yaml_path
-
-    def _hub_ops(self, f, max_dim=1920):
-        """Resizes and saves an image at reduced quality for web/app viewing; `f`: path to image, `max_dim`=1920 maximum
-        dimension.
-        """
-        f_new = self.im_dir / Path(f).name  # dataset-hub image filename
-        try:  # use PIL
-            im = Image.open(f)
-            r = max_dim / max(im.height, im.width)  # ratio
-            if r < 1.0:  # image too large
-                im = im.resize((int(im.width * r), int(im.height * r)))
-            im.save(f_new, "JPEG", quality=50, optimize=True)  # save
-        except Exception as e:  # use OpenCV
-            LOGGER.info(f"WARNING ⚠️ HUB ops PIL failure {f}: {e}")
-            im = cv2.imread(f)
-            im_height, im_width = im.shape[:2]
-            r = max_dim / max(im_height, im_width)  # ratio
-            if r < 1.0:  # image too large
-                im = cv2.resize(im, (int(im_width * r), int(im_height * r)), interpolation=cv2.INTER_AREA)
-            cv2.imwrite(str(f_new), im)
-
-    def get_json(self, save=False, verbose=False):
-        """Generates dataset JSON for Ultralytics Platform, with optional saving and verbosity; rounds labels to int
-        class and 4 decimal floats.
-        """
-
-        def _round(labels):
-            """Update labels to integer class and 4 decimal place floats."""
-            return [[int(c), *(round(x, 4) for x in points)] for c, *points in labels]
-
-        for split in "train", "val", "test":
-            if self.data.get(split) is None:
-                self.stats[split] = None  # i.e. no test set
-                continue
-            dataset = LoadImagesAndLabels(self.data[split])  # load dataset
-            x = np.array(
-                [
-                    np.bincount(label[:, 0].astype(int), minlength=self.data["nc"])
-                    for label in TQDM(dataset.labels, total=dataset.n, desc="Statistics")
-                ]
-            )  # shape(128x80)
-            self.stats[split] = {
-                "instance_stats": {"total": int(x.sum()), "per_class": x.sum(0).tolist()},
-                "image_stats": {
-                    "total": dataset.n,
-                    "unlabelled": int(np.all(x == 0, 1).sum()),
-                    "per_class": (x > 0).sum(0).tolist(),
-                },
-                "labels": [{str(Path(k).name): _round(v.tolist())} for k, v in zip(dataset.im_files, dataset.labels)],
-            }
-
-        # Save, print and return
-        if save:
-            stats_path = self.hub_dir / "stats.json"
-            print(f"Saving {stats_path.resolve()}...")
-            with open(stats_path, "w") as f:
-                json.dump(self.stats, f)  # save stats.json
-        if verbose:
-            print(json.dumps(self.stats, indent=2, sort_keys=False))
-        return self.stats
-
-    def process_images(self):
-        """Compresses images for Ultralytics Platform, saving them to specified directory; supports 'train', 'val',
-        'test' splits.
-        """
-        for split in "train", "val", "test":
-            if self.data.get(split) is None:
-                continue
-            dataset = LoadImagesAndLabels(self.data[split])  # load dataset
-            desc = f"{split} images"
-            for _ in TQDM(ThreadPool(NUM_THREADS).imap(self._hub_ops, dataset.im_files), total=dataset.n, desc=desc):
-                pass
-        print(f"Done. All images saved to {self.im_dir}")
-        return self.im_dir

--- a/utils/general.py
+++ b/utils/general.py
@@ -831,37 +831,6 @@ def scale_boxes(img1_shape, boxes, img0_shape, ratio_pad=None):
     return boxes
 
 
-def scale_segments(img1_shape, segments, img0_shape, ratio_pad=None, normalize=False):
-    """Rescales segment coordinates from img1_shape to img0_shape, optionally normalizing, with support for padding
-    adjustments.
-    """
-    if ratio_pad is None:  # calculate from img0_shape
-        gain = min(img1_shape[0] / img0_shape[0], img1_shape[1] / img0_shape[1])  # gain  = old / new
-        pad = (img1_shape[1] - img0_shape[1] * gain) / 2, (img1_shape[0] - img0_shape[0] * gain) / 2  # wh padding
-    else:
-        gain = ratio_pad[0][0]
-        pad = ratio_pad[1]
-
-    segments[:, 0] -= pad[0]  # x padding
-    segments[:, 1] -= pad[1]  # y padding
-    segments /= gain
-    clip_segments(segments, img0_shape)
-    if normalize:
-        segments[:, 0] /= img0_shape[1]  # width
-        segments[:, 1] /= img0_shape[0]  # height
-    return segments
-
-
-def clip_segments(segments, shape):
-    """Clips segments to within image shape (height, width), supporting torch.Tensor and np.array inputs."""
-    if isinstance(segments, torch.Tensor):  # faster individually
-        segments[:, 0].clamp_(0, shape[1])  # x
-        segments[:, 1].clamp_(0, shape[0])  # y
-    else:  # np.array (faster grouped)
-        segments[:, 0] = segments[:, 0].clip(0, shape[1])  # x
-        segments[:, 1] = segments[:, 1].clip(0, shape[0])  # y
-
-
 # Keep local (do not dedup): anchor-based YOLOv3 head has an objectness channel; ultralytics NMS is anchor-free
 def non_max_suppression(
     prediction,

--- a/utils/loggers/__init__.py
+++ b/utils/loggers/__init__.py
@@ -213,11 +213,7 @@ class Loggers:
             self.comet_logger.on_val_start()
 
     def on_val_image_end(self, pred, predn, path, names, im):
-        """Callback for logging a single validation image and its predictions to WandB or ClearML at the end of
-        validation.
-        """
-        if self.wandb:
-            self.wandb.val_one_image(pred, predn, path, names, im)
+        """Callback for logging a single validation image and its predictions to ClearML at the end of validation."""
         if self.clearml:
             self.clearml.log_image_with_boxes(path, pred, names, im)
 

--- a/utils/loggers/comet/comet_utils.py
+++ b/utils/loggers/comet/comet_utils.py
@@ -96,29 +96,6 @@ def set_opt_parameters(opt, experiment):
     opt.hyp = hyp_yaml_path
 
 
-def check_comet_weights(opt):
-    """Downloads model weights from Comet and updates the weights path to point to saved weights location.
-
-    Args:
-        opt (argparse.Namespace): Command Line arguments passed to YOLOv3 training script
-
-    Returns:
-        None/bool: Return True if weights are successfully downloaded else return None
-    """
-    if comet_ml is None:
-        return
-
-    if isinstance(opt.weights, str) and opt.weights.startswith(COMET_PREFIX):
-        api = comet_ml.API()
-        resource = urlparse(opt.weights)
-        experiment_path = f"{resource.netloc}{resource.path}"
-        experiment = api.get(experiment_path)
-        download_model_checkpoint(opt, experiment)
-        return True
-
-    return None
-
-
 def check_comet_resume(opt):
     """Restores run parameters to its original state based on the model checkpoint and logged Experiment parameters.
 

--- a/utils/loggers/comet/hpo.py
+++ b/utils/loggers/comet/hpo.py
@@ -76,12 +76,6 @@ def get_args(known=False):
     parser.add_argument("--comet_optimizer_id", type=str, help="Comet: ID of the Comet Optimizer sweep.")
     parser.add_argument("--comet_optimizer_objective", type=str, help="Comet: Set to 'minimize' or 'maximize'.")
     parser.add_argument("--comet_optimizer_metric", type=str, help="Comet: Metric to Optimize.")
-    parser.add_argument(
-        "--comet_optimizer_workers",
-        type=int,
-        default=1,
-        help="Comet: Number of Parallel Workers to use with the Comet Optimizer.",
-    )
 
     return parser.parse_known_args()[0] if known else parser.parse_args()
 

--- a/utils/loggers/wandb/wandb_utils.py
+++ b/utils/loggers/wandb/wandb_utils.py
@@ -126,9 +126,6 @@ class WandbLogger:
         )
         LOGGER.info(f"Saving model artifact on epoch {epoch + 1}")
 
-    def val_one_image(self, pred, predn, path, names, im):
-        """Handle a single validation image and its predictions (currently a no-op placeholder)."""
-
     def log(self, log_dict):
         """Save the metrics to the logging dictionary.
 

--- a/utils/plots.py
+++ b/utils/plots.py
@@ -4,7 +4,6 @@
 import contextlib
 import math
 import os
-from copy import copy
 from pathlib import Path
 
 import cv2
@@ -19,7 +18,7 @@ from scipy.ndimage import gaussian_filter1d
 from ultralytics.utils.plotting import Annotator
 
 from utils import TryExcept, threaded
-from utils.general import LOGGER, clip_boxes, increment_path, xywh2xyxy, xyxy2xywh
+from utils.general import LOGGER, xywh2xyxy, xyxy2xywh
 from utils.metrics import fitness
 
 # Settings
@@ -111,24 +110,6 @@ def hist2d(x, y, n=100):
     return np.log(hist[xidx, yidx])
 
 
-def butter_lowpass_filtfilt(data, cutoff=1500, fs=50000, order=5):
-    """Applies a low-pass Butterworth filter using forward-backward method.
-
-    See: https://stackoverflow.com/questions/28536191/how-to-filter-smooth-with-scipy-numpy
-    """
-    from scipy.signal import butter, filtfilt
-
-    # https://stackoverflow.com/questions/28536191/how-to-filter-smooth-with-scipy-numpy
-    def butter_lowpass(cutoff, fs, order):
-        """Design and return low-pass Butterworth filter coefficients for the given cutoff, sample rate, and order."""
-        nyq = 0.5 * fs
-        normal_cutoff = cutoff / nyq
-        return butter(order, normal_cutoff, btype="low", analog=False)
-
-    b, a = butter_lowpass(cutoff, fs, order=order)
-    return filtfilt(b, a, data)  # forward-backward filter
-
-
 def output_to_target(output, max_det=300):
     """Converts model output to [batch_id, class_id, x, y, w, h, conf] format for plotting, handling up to `max_det`
     detections.
@@ -206,53 +187,6 @@ def plot_images(images, targets, paths=None, fname="images.jpg", names=None):
                     label = f"{cls}" if labels else f"{cls} {conf[j]:.1f}"
                     annotator.box_label(box, label, color=color)
     annotator.im.save(fname)  # save
-
-
-def plot_lr_scheduler(optimizer, scheduler, epochs=300, save_dir=""):
-    """Simulates and plots LR schedule over epochs, saving figure to `save_dir`."""
-    optimizer, scheduler = copy(optimizer), copy(scheduler)  # do not modify originals
-    y = []
-    for _ in range(epochs):
-        scheduler.step()
-        y.append(optimizer.param_groups[0]["lr"])
-    plt.plot(y, ".-", label="LR")
-    plt.xlabel("epoch")
-    plt.ylabel("LR")
-    plt.grid()
-    plt.xlim(0, epochs)
-    plt.ylim(0)
-    plt.savefig(Path(save_dir) / "LR.png", dpi=200)
-    plt.close()
-
-
-def plot_val_txt():  # from utils.plots import *; plot_val()
-    """Plots 2D and 1D histograms of object center locations from 'val.txt', saving as 'hist2d.png' and 'hist1d.png'."""
-    x = np.loadtxt("val.txt", dtype=np.float32)
-    box = xyxy2xywh(x[:, :4])
-    cx, cy = box[:, 0], box[:, 1]
-
-    _fig, ax = plt.subplots(1, 1, figsize=(6, 6), tight_layout=True)
-    ax.hist2d(cx, cy, bins=600, cmax=10, cmin=0)
-    ax.set_aspect("equal")
-    plt.savefig("hist2d.png", dpi=300)
-
-    _fig, ax = plt.subplots(1, 2, figsize=(12, 6), tight_layout=True)
-    ax[0].hist(cx, bins=600)
-    ax[1].hist(cy, bins=600)
-    plt.savefig("hist1d.png", dpi=200)
-
-
-def plot_targets_txt():  # from utils.plots import *; plot_targets_txt()
-    """Plots histograms for target attributes from 'targets.txt' and saves as 'targets.jpg'."""
-    x = np.loadtxt("targets.txt", dtype=np.float32).T
-    s = ["x targets", "y targets", "width targets", "height targets"]
-    _fig, ax = plt.subplots(2, 2, figsize=(8, 8), tight_layout=True)
-    ax = ax.ravel()
-    for i in range(4):
-        ax[i].hist(x[i], bins=100, label=f"{x[i].mean():.3g} +/- {x[i].std():.3g}")
-        ax[i].legend()
-        ax[i].set_title(s[i])
-    plt.savefig("targets.jpg", dpi=200)
 
 
 def plot_val_study(file="", dir="", x=None):  # from utils.plots import *; plot_val_study()
@@ -402,56 +336,3 @@ def plot_results(file="path/to/results.csv", dir=""):
     ax[1].legend()
     fig.savefig(save_dir / "results.png", dpi=200)
     plt.close()
-
-
-def profile_idetection(start=0, stop=0, labels=(), save_dir=""):
-    """Plots iDetection per-image logs from '*.txt', including metrics like storage and FPS; pass start, stop times,
-    labels, and save_dir.
-    """
-    ax = plt.subplots(2, 4, figsize=(12, 6), tight_layout=True)[1].ravel()
-    s = ["Images", "Free Storage (GB)", "RAM Usage (GB)", "Battery", "dt_raw (ms)", "dt_smooth (ms)", "real-world FPS"]
-    files = list(Path(save_dir).glob("frames*.txt"))
-    for fi, f in enumerate(files):
-        try:
-            results = np.loadtxt(f, ndmin=2).T[:, 90:-30]  # clip first and last rows
-            n = results.shape[1]  # number of rows
-            x = np.arange(start, min(stop, n) if stop else n)
-            results = results[:, x]
-            t = results[0] - results[0].min()  # set t0=0s
-            results[0] = x
-            for i, a in enumerate(ax):
-                if i < len(results):
-                    label = labels[fi] if len(labels) else f.stem.replace("frames_", "")
-                    a.plot(t, results[i], marker=".", label=label, linewidth=1, markersize=5)
-                    a.set_title(s[i])
-                    a.set_xlabel("time (s)")
-                    # if fi == len(files) - 1:
-                    #     a.set_ylim(bottom=0)
-                    for side in ["top", "right"]:
-                        a.spines[side].set_visible(False)
-                else:
-                    a.remove()
-        except Exception as e:
-            print(f"Warning: Plotting error for {f}; {e}")
-    ax[1].legend()
-    plt.savefig(Path(save_dir) / "idetection_profile.png", dpi=200)
-
-
-def save_one_box(xyxy, im, file=Path("im.jpg"), gain=1.02, pad=10, square=False, BGR=False, save=True):
-    """Saves/enhances a crop from `im` defined by `xyxy` to `file` or returns it; customizable with `gain`, `pad`,
-    `square`, `BGR`.
-    """
-    xyxy = torch.tensor(xyxy).view(-1, 4)
-    b = xyxy2xywh(xyxy)  # boxes
-    if square:
-        b[:, 2:] = b[:, 2:].max(1)[0].unsqueeze(1)  # attempt rectangle to square
-    b[:, 2:] = b[:, 2:] * gain + pad  # box wh * gain + pad
-    xyxy = xywh2xyxy(b).long()
-    clip_boxes(xyxy, im.shape)
-    crop = im[int(xyxy[0, 1]) : int(xyxy[0, 3]), int(xyxy[0, 0]) : int(xyxy[0, 2]), :: (1 if BGR else -1)]
-    if save:
-        file.parent.mkdir(parents=True, exist_ok=True)  # make directory
-        f = str(increment_path(file).with_suffix(".jpg"))
-        # cv2.imwrite(f, crop)  # save BGR, https://github.com/ultralytics/yolov5/issues/7007 chroma subsampling issue
-        Image.fromarray(crop[..., ::-1]).save(f, quality=95, subsampling=0)  # save RGB
-    return crop

--- a/utils/triton.py
+++ b/utils/triton.py
@@ -31,11 +31,6 @@ class TritonRemoteModel:
             self.model_name = model_repository.models[0].name
             self.metadata = self.client.get_model_metadata(self.model_name, as_json=True)
 
-            def create_input_placeholders() -> list[InferInput]:
-                return [
-                    InferInput(i["name"], [int(s) for s in i["shape"]], i["datatype"]) for i in self.metadata["inputs"]
-                ]
-
         else:
             from tritonclient.http import InferenceServerClient, InferInput
 
@@ -44,10 +39,8 @@ class TritonRemoteModel:
             self.model_name = model_repository[0]["name"]
             self.metadata = self.client.get_model_metadata(self.model_name)
 
-            def create_input_placeholders() -> list[InferInput]:
-                return [
-                    InferInput(i["name"], [int(s) for s in i["shape"]], i["datatype"]) for i in self.metadata["inputs"]
-                ]
+        def create_input_placeholders() -> list[InferInput]:
+            return [InferInput(i["name"], [int(s) for s in i["shape"]], i["datatype"]) for i in self.metadata["inputs"]]
 
         self._create_input_placeholders_fn = create_input_placeholders
 


### PR DESCRIPTION
Removes ~390 lines that no code path reaches. Every item was checked with a repo-wide `grep -rn --exclude-dir=.git` covering READMEs, `tutorial.ipynb`, workflows and YAML.

### `utils/plots.py` (−118)
`butter_lowpass_filtfilt`, `plot_lr_scheduler`, `plot_val_txt`, `plot_targets_txt`, `profile_idetection`, and the local `save_one_box`.

`save_one_box` was already shadowed: both live call sites (`detect.py:243`, `models/common.py:925`) import ultralytics' version at `detect.py:44` / `models/common.py:23`, and nothing imported the local definition. Orphans `from copy import copy` plus `clip_boxes` and `increment_path` from the `utils.general` import. `plot_lr_scheduler` had exactly one remaining mention — a trailing comment on `train.py:249` — removed here so nothing points at a deleted function.

### `utils/general.py` (−31)
`scale_segments` and `clip_segments`. `clip_segments`' only consumer was `scale_segments`, which had none, so the pair drops with no import replacement. yolov5 keeps its copy because `segment/predict.py` calls it; yolov3 has no `segment/` triad.

### `utils/dataloaders.py` (−177)
`HUBDatasetStats` — no callers, only self-references inside its own docstring. Ultralytics HUB dataset stats are maintained in the `ultralytics` package. Also `flatten_recursive` and `extract_boxes`, REPL-only helpers that yolov5 already deleted. Orphans `json`, `yaml`, `shutil`, and `check_dataset` / `check_yaml` / `unzip_file` / `xywh2xyxy` from the `utils.general` import block. `ThreadPool`, `glob`, `hashlib`, `contextlib` and the PIL imports all stay — still used.

### Dead surface (−51)
- `utils/loggers/comet/comet_utils.py` `check_comet_weights` — unreferenced; `comet://` weights were never a documented input here.
- `models/experimental.py` `Ensemble.__init__` — body was only `super().__init__()`, which `nn.ModuleList` does anyway.
- `utils/loggers/wandb/wandb_utils.py` `val_one_image` — body is a docstring and nothing else, so the `if self.wandb:` branch in `utils/loggers/__init__.py` called a no-op. Its docstring said "to WandB or ClearML"; now accurate.
- `utils/loggers/comet/hpo.py` `--comet_optimizer_workers` — parsed, never read. `get_args(known=True)` uses `parse_known_args`, so any stale invocation still works.
- `utils/callbacks.py` `Callbacks.get_registered_actions` — no callers.

### `utils/triton.py` (−5)
`create_input_placeholders` was defined twice with byte-identical bodies, once inside the GRPC branch and once inside the HTTP branch. Both close over a branch-local `InferInput`, so one definition placed after the `if/else` captures whichever branch ran. `from __future__ import annotations` is already present, so the `list[InferInput]` return annotation is never evaluated and this stays valid on the Python 3.8 CI floor.

### Adjacent
`models/experimental.py` used a bare `print()` where yolov5 uses `LOGGER.info` — swapped for consistency (+1 line).

### Explicitly not touched
`export_formats()` stays a `pandas.DataFrame`. Importing `ultralytics.engine.exporter.export_formats` looks tempting but returns 21 rows × 7 columns against this repo's 12 × 5, which breaks the 11-way flag unpack at `export.py:703`, the `assert i not in (6, 7, 8, 9, 10)` guard in `benchmarks.py`, and `types[8] &= not types[9]` in `models/common.py` — and its CoreML suffix is `.mlpackage` where this repo writes `.mlmodel`. `AGENTS.md` already documents that positional coupling.

### Validation
- `ruff check .` / `ruff format --check .` clean
- `python train.py --imgsz 64 --batch 32 --weights yolov3-tiny.pt --cfg yolov3-tiny.yaml --epochs 1 --device cpu`
- `python val.py --imgsz 64 --batch 32 --weights yolov3-tiny.pt --device cpu` → `all 128 929 0.597 0.0436 0.0631 0.0276`
- `python detect.py --weights yolov3-tiny.pt --source data/images --device cpu --save-crop` (exercises the ultralytics `save_one_box` path)
- Import smoke across `train`, `val`, `detect`, `export`, `hubconf`, `benchmarks`, `utils.triton`, `utils.callbacks`, `models.experimental`, `utils.loggers`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Streamlines the YOLOv3 codebase by removing legacy utilities, simplifying logging, and consolidating Triton input handling. 🧹

### 📊 Key Changes
- Replaced ensemble creation `print()` output with the project `LOGGER` for consistent logging. 📝
- Simplified `Ensemble` initialization by relying on the parent `ModuleList` constructor.
- Removed unused or legacy dataset utilities, including:
  - Recursive dataset flattening.
  - Detection-to-classification box extraction.
  - HUB dataset statistics and image-processing helpers.
- Removed obsolete plotting and image-cropping helpers, including learning-rate plots, target visualizations, and iDetection profiling.
- Removed unused segmentation scaling and clipping functions from `utils/general.py`.
- Cleaned up callback and Comet integrations by removing unused APIs and options.
- Removed the inactive Weights & Biases per-image validation callback.
- Consolidated Triton input-placeholder creation so HTTP and gRPC clients share the same implementation.
- Removed an outdated commented learning-rate scheduler plotting reference. ✨

### 🎯 Purpose & Impact
- Reduces maintenance overhead and keeps the YOLOv3 repository focused on actively used functionality. 🚀
- Improves logging consistency by integrating ensemble messages with the standard logger.
- Lowers code complexity and eliminates several unused dependencies and imports.
- Preserves existing training, inference, and Triton behavior while making the implementation easier to maintain.
- Users relying on removed helper functions or legacy Comet, HUB, plotting, or segmentation utilities may need to migrate to newer Ultralytics tooling, such as the [Ultralytics Platform](https://platform.ultralytics.com).