### PR TITLE
Use ultralytics' LOGGER instead of a private one

### DIFF
--- a/benchmarks.py
+++ b/benchmarks.py
@@ -100,7 +100,7 @@ def run(
         except Exception as e:
             if hard_fail:
                 assert type(e) is AssertionError, f"Benchmark --hard-fail for {name}: {e}"
-            LOGGER.warning(f"WARNING ⚠️ Benchmark failure for {name}: {e}")
+            LOGGER.warning(f"Benchmark failure for {name}: {e}")
             y.append([name, None, None, None])  # mAP, t_inference
         if pt_only and i == 0:
             break  # break after PyTorch

--- a/export.py
+++ b/export.py
@@ -492,7 +492,7 @@ def export_engine(model, im, file, half, dynamic, simplify, workspace=4, verbose
 
     if dynamic:
         if im.shape[0] <= 1:
-            LOGGER.warning(f"{prefix} WARNING ⚠️ --dynamic model requires maximum --batch-size argument")
+            LOGGER.warning(f"{prefix} --dynamic model requires maximum --batch-size argument")
         profile = builder.create_optimization_profile()
         for inp in inputs:
             profile.set_shape(inp.name, (1, *im.shape[1:]), (max(1, im.shape[0] // 2), *im.shape[1:]), im.shape)

--- a/hubconf.py
+++ b/hubconf.py
@@ -46,7 +46,9 @@ def _create(name, pretrained=True, channels=3, classes=80, autoshape=True, verbo
     from models.experimental import attempt_load
     from models.yolo import DetectionModel
     from utils.downloads import attempt_download
-    from utils.general import LOGGER, ROOT, check_requirements, intersect_dicts, logging
+    import logging
+
+    from utils.general import LOGGER, ROOT, check_requirements, intersect_dicts
     from utils.torch_utils import select_device
 
     if not verbose:

--- a/train.py
+++ b/train.py
@@ -261,7 +261,7 @@ def train(hyp, opt, device, callbacks):  # hyp is path/to/hyp.yaml or hyp dictio
     # DP mode
     if cuda and RANK == -1 and torch.cuda.device_count() > 1:
         LOGGER.warning(
-            "WARNING ⚠️ DP not recommended, use torch.distributed.run for best DDP Multi-GPU results.\n"
+            "DP not recommended, use torch.distributed.run for best DDP Multi-GPU results.\n"
             "See Multi-GPU Tutorial at https://docs.ultralytics.com/yolov5/tutorials/multi_gpu_training to get started."
         )
         model = torch.nn.DataParallel(model)

--- a/utils/autoanchor.py
+++ b/utils/autoanchor.py
@@ -129,7 +129,7 @@ def kmean_anchors(dataset="./data/coco128.yaml", n=9, img_size=640, thr=4.0, gen
     # Filter
     i = (wh0 < 3.0).any(1).sum()
     if i:
-        LOGGER.info(f"{PREFIX}WARNING ⚠️ Extremely small objects found: {i} of {len(wh0)} labels are <3 pixels in size")
+        LOGGER.warning(f"{PREFIX}Extremely small objects found: {i} of {len(wh0)} labels are <3 pixels in size")
     wh = wh0[(wh0 >= 2.0).any(1)].astype(np.float32)  # filter > 2 pixels
     # wh = wh * (npr.rand(wh.shape[0], 1) * 0.9 + 0.1)  # multiply by random scale 0-1
 
@@ -141,7 +141,7 @@ def kmean_anchors(dataset="./data/coco128.yaml", n=9, img_size=640, thr=4.0, gen
         k = kmeans(wh / s, n, iter=30)[0] * s  # points
         assert n == len(k)  # kmeans may return fewer points than requested if wh is insufficient or too similar
     except Exception:
-        LOGGER.warning(f"{PREFIX}WARNING ⚠️ switching strategies from kmeans to random init")
+        LOGGER.warning(f"{PREFIX}switching strategies from kmeans to random init")
         k = np.sort(npr.rand(n * 2)).reshape(n, 2) * img_size  # random init
     wh, wh0 = (torch.tensor(x, dtype=torch.float32) for x in (wh, wh0))
     k = print_results(k, verbose=False)

--- a/utils/autobatch.py
+++ b/utils/autobatch.py
@@ -75,7 +75,7 @@ def autobatch(model, imgsz=640, fraction=0.8, batch_size=16):
             b = batch_sizes[max(i - 1, 0)]  # select prior safe point
     if b < 1 or b > 1024:  # b outside of safe range
         b = batch_size
-        LOGGER.warning(f"{prefix}WARNING ⚠️ CUDA anomaly detected, recommend restart environment and retry command.")
+        LOGGER.warning(f"{prefix}CUDA anomaly detected, recommend restart environment and retry command.")
 
     fraction = (np.polyval(p, b) + r + a) / t  # actual fraction predicted
     LOGGER.info(f"{prefix}Using batch-size {b} for {d} {t * fraction:.2f}G/{t:.2f}G ({fraction * 100:.0f}%) ✅")

--- a/utils/dataloaders.py
+++ b/utils/dataloaders.py
@@ -93,7 +93,7 @@ def create_dataloader(
 ):
     """Creates a DataLoader for training, with options for augmentation, caching, and parallelization."""
     if rect and shuffle:
-        LOGGER.warning("WARNING ⚠️ --rect is incompatible with DataLoader shuffle, setting shuffle=False")
+        LOGGER.warning("--rect is incompatible with DataLoader shuffle, setting shuffle=False")
         shuffle = False
     with torch_distributed_zero_first(rank):  # init dataset *.cache only once if DDP
         dataset = LoadImagesAndLabels(
@@ -384,7 +384,7 @@ class LoadStreams:
         self.auto = auto and self.rect
         self.transforms = transforms  # optional
         if not self.rect:
-            LOGGER.warning("WARNING ⚠️ Stream shapes differ. For optimal performance supply similarly-shaped streams.")
+            LOGGER.warning("Stream shapes differ. For optimal performance supply similarly-shaped streams.")
 
     def update(self, i, cap, stream):
         """Reads frames from stream `i` into `self.imgs` at intervals defined by `self.vid_stride`, handling
@@ -399,7 +399,7 @@ class LoadStreams:
                 if success:
                     self.imgs[i] = im
                 else:
-                    LOGGER.warning("WARNING ⚠️ Video stream unresponsive, please check your IP camera connection.")
+                    LOGGER.warning("Video stream unresponsive, please check your IP camera connection.")
                     self.imgs[i] = np.zeros_like(self.imgs[i])
                     cap.open(stream)  # re-open stream if signal was lost
             time.sleep(0.0)  # wait time
@@ -635,7 +635,7 @@ class LoadImagesAndLabels(Dataset):
         if msgs:
             LOGGER.info("\n".join(msgs))
         if nf == 0:
-            LOGGER.warning(f"{prefix}WARNING ⚠️ No labels found in {path}. {HELP_URL}")
+            LOGGER.warning(f"{prefix}No labels found in {path}. {HELP_URL}")
         x["hash"] = get_hash(self.label_files + self.im_files)
         x["results"] = nf, nm, ne, nc, len(self.im_files)
         x["msgs"] = msgs  # warnings
@@ -645,7 +645,7 @@ class LoadImagesAndLabels(Dataset):
             path.with_suffix(".cache.npy").rename(path)  # remove .npy suffix
             LOGGER.info(f"{prefix}New cache created: {path}")
         except Exception as e:
-            LOGGER.warning(f"{prefix}WARNING ⚠️ Cache directory {path.parent} is not writeable: {e}")  # not writeable
+            LOGGER.warning(f"{prefix}Cache directory {path.parent} is not writeable: {e}")  # not writeable
         return x
 
     def __len__(self):

--- a/utils/general.py
+++ b/utils/general.py
@@ -6,8 +6,6 @@ from __future__ import annotations
 import contextlib
 import glob
 import inspect
-import logging
-import logging.config
 import os
 import platform
 import random
@@ -34,7 +32,7 @@ import torchvision
 import yaml
 from ultralytics.data.converter import coco80_to_coco91_class  # noqa: F401
 from ultralytics.utils import TQDM as _TQDM
-from ultralytics.utils import colorstr, get_default_args  # noqa: F401
+from ultralytics.utils import LOGGER, colorstr, get_default_args  # noqa: F401
 from ultralytics.utils.checks import check_requirements as check_requirements_ultralytics
 from ultralytics.utils.checks import check_version as check_version_ultralytics
 from ultralytics.utils.checks import is_ascii, print_args  # noqa: F401
@@ -137,43 +135,6 @@ def is_writeable(dir, test=False):
         return True
     except OSError:
         return False
-
-
-LOGGING_NAME = "yolov3"
-
-
-def set_logging(name=LOGGING_NAME, verbose=True):
-    """Configures logging with specified verbosity; 'name' sets logger identity, 'verbose' toggles logging level."""
-    rank = int(os.getenv("RANK", "-1"))  # rank in world for Multi-GPU trainings
-    level = logging.INFO if verbose and rank in {-1, 0} else logging.ERROR
-    logging.config.dictConfig(
-        {
-            "version": 1,
-            "disable_existing_loggers": False,
-            "formatters": {name: {"format": "%(message)s"}},
-            "handlers": {
-                name: {
-                    "class": "logging.StreamHandler",
-                    "formatter": name,
-                    "level": level,
-                }
-            },
-            "loggers": {
-                name: {
-                    "level": level,
-                    "handlers": [name],
-                    "propagate": False,
-                }
-            },
-        }
-    )
-
-
-set_logging(LOGGING_NAME)  # run before defining LOGGER
-LOGGER = logging.getLogger(LOGGING_NAME)  # define globally (used in train.py, val.py, detect.py, etc.)
-if platform.system() == "Windows":
-    for fn in LOGGER.info, LOGGER.warning:
-        setattr(LOGGER, fn.__name__, lambda x, fn=fn: fn(emojis(x)))  # emoji safe logging
 
 
 def user_config_dir(dir="Ultralytics", env_var="YOLOV3_CONFIG_DIR"):
@@ -326,7 +287,7 @@ def check_img_size(imgsz, s=32, floor=0):
         imgsz = list(imgsz)  # convert to list if tuple
         new_size = [max(make_divisible(x, int(s)), floor) for x in imgsz]
     if new_size != imgsz:
-        LOGGER.warning(f"WARNING ⚠️ --img-size {imgsz} must be multiple of max stride {s}, updating to {new_size}")
+        LOGGER.warning(f"--img-size {imgsz} must be multiple of max stride {s}, updating to {new_size}")
     return new_size
 
 
@@ -342,7 +303,7 @@ def check_imshow(warn=False):
         return True
     except Exception as e:
         if warn:
-            LOGGER.warning(f"WARNING ⚠️ Environment does not support cv2.imshow() or PIL Image.show()\n{e}")
+            LOGGER.warning(f"Environment does not support cv2.imshow() or PIL Image.show()\n{e}")
         return False
 
 
@@ -782,7 +743,7 @@ def non_max_suppression(
         if mps:
             output[xi] = output[xi].to(device)
         if (time.time() - t) > time_limit:
-            LOGGER.warning(f"WARNING ⚠️ NMS time limit {time_limit:.3f}s exceeded")
+            LOGGER.warning(f"NMS time limit {time_limit:.3f}s exceeded")
             break  # time limit exceeded
 
     return output

--- a/utils/loggers/__init__.py
+++ b/utils/loggers/__init__.py
@@ -119,7 +119,7 @@ class Loggers:
                 self.clearml = None
                 prefix = colorstr("ClearML: ")
                 LOGGER.warning(
-                    f"{prefix}WARNING ⚠️ ClearML is installed but not configured, skipping ClearML logging."
+                    f"{prefix}ClearML is installed but not configured, skipping ClearML logging."
                     f" See https://docs.ultralytics.com/yolov5/tutorials/clearml_logging_integration#readme"
                 )
 
@@ -415,7 +415,7 @@ def log_tensorboard_graph(tb, model, imgsz=(640, 640)):
             warnings.simplefilter("ignore")  # suppress jit trace warning
             tb.add_graph(torch.jit.trace(de_parallel(model), im, strict=False), [])
     except Exception as e:
-        LOGGER.warning(f"WARNING ⚠️ TensorBoard graph visualization failure {e}")
+        LOGGER.warning(f"TensorBoard graph visualization failure {e}")
 
 
 def web_project_name(project):

--- a/utils/loggers/wandb/wandb_utils.py
+++ b/utils/loggers/wandb/wandb_utils.py
@@ -18,7 +18,7 @@ if str(ROOT) not in sys.path:
     sys.path.append(str(ROOT))  # add ROOT to PATH
 RANK = int(os.getenv("RANK", "-1"))
 DEPRECATION_WARNING = (
-    f"{colorstr('wandb')}: WARNING ⚠️ wandb is deprecated and will be removed in a future release. "
+    f"{colorstr('wandb')}: wandb is deprecated and will be removed in a future release. "
     f"See supported integrations at https://github.com/ultralytics/yolov3#integrations."
 )
 

--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -53,7 +53,7 @@ def smartCrossEntropyLoss(label_smoothing=0.0):
     if check_version(torch.__version__, "1.10.0"):
         return nn.CrossEntropyLoss(label_smoothing=label_smoothing)
     if label_smoothing > 0:
-        LOGGER.warning(f"WARNING ⚠️ label smoothing {label_smoothing} requires torch>=1.10.0")
+        LOGGER.warning(f"label smoothing {label_smoothing} requires torch>=1.10.0")
     return nn.CrossEntropyLoss()
 
 

--- a/val.py
+++ b/val.py
@@ -432,7 +432,7 @@ def run(
     pf = "%22s" + "%11i" * 2 + "%11.3g" * 4  # print format
     LOGGER.info(pf % ("all", seen, nt.sum(), mp, mr, map50, map))
     if nt.sum() == 0:
-        LOGGER.warning(f"WARNING ⚠️ no labels found in {task} set, can not compute metrics without labels")
+        LOGGER.warning(f"no labels found in {task} set, can not compute metrics without labels")
 
     # Print results per class
     if (verbose or (nc < 50 and not training)) and nc > 1 and len(stats):
@@ -594,9 +594,9 @@ def main(opt):
 
     if opt.task in ("train", "val", "test"):  # run normally
         if opt.conf_thres > 0.001:  # https://github.com/ultralytics/yolov5/issues/1466
-            LOGGER.info(f"WARNING ⚠️ confidence threshold {opt.conf_thres} > 0.001 produces invalid results")
+            LOGGER.warning(f"confidence threshold {opt.conf_thres} > 0.001 produces invalid results")
         if opt.save_hybrid:
-            LOGGER.info("WARNING ⚠️ --save-hybrid will return high mAP from hybrid labels, not from predictions alone")
+            LOGGER.warning("--save-hybrid will return high mAP from hybrid labels, not from predictions alone")
         run(**vars(opt))
 
     else:


### PR DESCRIPTION
> Stacked on #2462. Base retargets to `master` as the chain merges. Mirrors ultralytics/yolov5#13837.

`utils/general.py` stood up its own `"yolov3"` logger through `logging.config.dictConfig` and exported it. ultralytics already builds an equivalent, so `LOGGING_NAME`, `set_logging`, the module-scope call, the `LOGGER = logging.getLogger(...)` assignment and the Windows-only emoji monkeypatch are deleted in favour of one name on the existing `from ultralytics.utils import ...` line.

`set_logging` has **zero external callers**, so there is no per-rank `set_logging(verbose=RANK in {-1, 0})` to preserve. Same `%(message)s` format, same `INFO if verbose and rank in {-1, 0} else ERROR` rule, same `propagate=False`. ultralytics' `PrefixFormatter` runs `emojis()` on every level, superseding the Windows-only patch.

### `hubconf.py` — the edit that makes this safe

`hubconf.py:49` was importing stdlib `logging` **through** this module:

```python
from utils.general import LOGGER, ROOT, check_requirements, intersect_dicts, logging
```

Deleting `set_logging` orphans `import logging` in `utils/general.py`, and the `ruff --fix` that Ultralytics Actions pushes would strip it — breaking `torch.hub` loading at `LOGGER.setLevel(logging.WARNING)`. `hubconf.py` now imports it directly. I re-ran `ruff check --fix .` and re-imported `hubconf` to confirm the format bot can't break it.

### The doubled `WARNING ⚠️` literal

ultralytics' formatter prepends the marker on `WARNING`, so embedded literals doubled. Of 26 sites: **21 stripped**, **3 promoted** from `LOGGER.info` to `LOGGER.warning` then stripped (`val.py:597`, `val.py:599`, `utils/autoanchor.py:132` — all warnings written at info level), and **5 left alone**:

| site | why it keeps the literal |
|---|---|
| `utils/metrics.py:187` | `@TryExcept("WARNING ⚠️ ConfusionMatrix plot failure")` — this repo's `TryExcept.__exit__` uses a bare `print(emojis(...))`, **not** `LOGGER`, so it was never doubled. Stripping would delete the marker outright. |
| `utils/dataloaders.py:882`, `:903`, `:913` | `verify_image_label` messages accumulated into `msgs` and emitted by a single `LOGGER.info("\n".join(msgs))` (`:505`, `:636`) — not doubled, and promoting would only prefix the first line of the joined block |
| `utils/loggers/wandb/wandb_utils.py:3` | a Python source comment |

### No `check_version` change needed here

yolov5 required relocating a marker because its `check_version` built one string feeding both an `assert` and `LOGGER.warning`. This repo's `check_version` is already a one-line delegation to `check_version_ultralytics`, so that landmine doesn't exist.

### Log output moves from stderr to stdout

ultralytics' handler is `logging.StreamHandler(sys.stdout)`; the local one defaulted to stderr. Confirmed `python val.py ... 2>/dev/null` still prints the whole run log.

Secondary cosmetic effect: at `f"{prefix}WARNING ⚠️ ..."` sites the auto-prefix lands outside the `colorstr` prefix, so `AutoBatch: WARNING ⚠️ msg` becomes `WARNING ⚠️ AutoBatch: msg`.

### Validation

| check | result |
|---|---|
| `val.py --weights yolov3-tiny.pt --data coco128.yaml --img 640 --device cpu 2>/dev/null` | full log on stdout, `all 128 929 0.537 0.43 0.472 0.259` |
| `hubconf._create(...)` | loads, returns `AutoShape` |
| `ruff check --fix .` re-run, then `import hubconf` | still imports |
| `train.py --epochs 1 --device cpu` | pass |
| `ruff check .` / `ruff format --check .` | clean |