### PR TITLE
Use ultralytics' LOGGER everywhere

### DIFF
--- a/benchmarks.py
+++ b/benchmarks.py
@@ -100,7 +100,7 @@ def run(
         except Exception as e:
             if hard_fail:
                 assert type(e) is AssertionError, f"Benchmark --hard-fail for {name}: {e}"
-            LOGGER.warning(f"WARNING ⚠️ Benchmark failure for {name}: {e}")
+            LOGGER.warning(f"Benchmark failure for {name}: {e}")
             y.append([name, None, None, None])  # mAP, t_inference
         if pt_only and i == 0:
             break  # break after PyTorch

--- a/export.py
+++ b/export.py
@@ -416,7 +416,7 @@ def export_coreml(model, im, file, int8, half, nms, prefix=colorstr("CoreML:")):
                 warnings.filterwarnings("ignore", category=DeprecationWarning)  # suppress numpy==1.20 float warning
                 ct_model = ct.models.neural_network.quantization_utils.quantize_weights(ct_model, bits, mode)
         else:
-            print(f"{prefix} quantization only supported on macOS, skipping...")
+            LOGGER.warning(f"{prefix} quantization only supported on macOS, skipping...")
     ct_model.save(f)
     return f, ct_model
 
@@ -492,7 +492,7 @@ def export_engine(model, im, file, half, dynamic, simplify, workspace=4, verbose
 
     if dynamic:
         if im.shape[0] <= 1:
-            LOGGER.warning(f"{prefix} WARNING ⚠️ --dynamic model requires maximum --batch-size argument")
+            LOGGER.warning(f"{prefix} --dynamic model requires maximum --batch-size argument")
         profile = builder.create_optimization_profile()
         for inp in inputs:
             profile.set_shape(inp.name, (1, *im.shape[1:]), (max(1, im.shape[0] // 2), *im.shape[1:]), im.shape)
@@ -527,7 +527,7 @@ def pipeline_coreml(model, im, file, names, y, prefix=colorstr("CoreML Pipeline:
     import coremltools as ct
     from PIL import Image
 
-    print(f"{prefix} starting pipeline with coremltools {ct.__version__}...")
+    LOGGER.info(f"{prefix} starting pipeline with coremltools {ct.__version__}...")
     _batch_size, _ch, h, w = list(im.shape)  # BCHW
     t = time.time()
 
@@ -566,7 +566,7 @@ def pipeline_coreml(model, im, file, names, y, prefix=colorstr("CoreML Pipeline:
     # flexible_shape_utils.update_image_size_range(spec, feature_name='image', size_range=r)
 
     # Print
-    print(spec.description)
+    LOGGER.info(spec.description)
 
     # Model from spec
     model = ct.models.MLModel(spec)
@@ -650,7 +650,7 @@ def pipeline_coreml(model, im, file, names, y, prefix=colorstr("CoreML Pipeline:
     model.output_description["confidence"] = 'Boxes × Class confidence (see user-defined metadata "classes")'
     model.output_description["coordinates"] = "Boxes × [x, y, width, height] (relative to image size)"
     model.save(f)  # pipelined
-    print(f"{prefix} pipeline success ({time.time() - t:.2f}s), saved as {f} ({file_size(f):.1f} MB)")
+    LOGGER.info(f"{prefix} pipeline success ({time.time() - t:.2f}s), saved as {f} ({file_size(f):.1f} MB)")
 
 
 @smart_inference_mode()

--- a/hubconf.py
+++ b/hubconf.py
@@ -40,15 +40,17 @@ def _create(name, pretrained=True, channels=3, classes=80, autoshape=True, verbo
         model = _create('yolov3')
         ```
     """
+    import logging
     from pathlib import Path
 
     from models.common import AutoShape, DetectMultiBackend
     from models.experimental import attempt_load
     from models.yolo import DetectionModel
     from utils.downloads import attempt_download
-    from utils.general import LOGGER, ROOT, check_requirements, intersect_dicts, logging
+    from utils.general import LOGGER, ROOT, check_requirements, intersect_dicts
     from utils.torch_utils import select_device
 
+    prev_level = LOGGER.level
     if not verbose:
         LOGGER.setLevel(logging.WARNING)
     check_requirements(ROOT / "requirements.txt", exclude=("opencv-python", "tensorboard", "ultralytics-thop"))
@@ -74,7 +76,7 @@ def _create(name, pretrained=True, channels=3, classes=80, autoshape=True, verbo
                 if len(ckpt["model"].names) == classes:
                     model.names = ckpt["model"].names  # set class names attribute
         if not verbose:
-            LOGGER.setLevel(logging.INFO)  # reset to default
+            LOGGER.setLevel(prev_level)  # restore, LOGGER is shared with ultralytics
         return model.to(device)
 
     except Exception as e:

--- a/hubconf.py
+++ b/hubconf.py
@@ -75,14 +75,15 @@ def _create(name, pretrained=True, channels=3, classes=80, autoshape=True, verbo
                 model.load_state_dict(csd, strict=False)  # load
                 if len(ckpt["model"].names) == classes:
                     model.names = ckpt["model"].names  # set class names attribute
-        if not verbose:
-            LOGGER.setLevel(prev_level)  # restore, LOGGER is shared with ultralytics
         return model.to(device)
 
     except Exception as e:
         help_url = "https://docs.ultralytics.com/yolov5/tutorials/pytorch_hub_model_loading"
         s = f"{e}. Cache may be out of date, try `force_reload=True` or see {help_url} for help."
         raise RuntimeError(s) from e
+
+    finally:
+        LOGGER.setLevel(prev_level)  # restore on both paths, LOGGER is shared with ultralytics
 
 
 def custom(path="path/to/model.pt", autoshape=True, _verbose=True, device=None):

--- a/models/yolo.py
+++ b/models/yolo.py
@@ -409,7 +409,7 @@ if __name__ == "__main__":
             try:
                 _ = Model(cfg)
             except Exception as e:
-                print(f"Error in {cfg}: {e}")
+                LOGGER.error(f"in {cfg}: {e}")
 
     else:  # report fused model summary
         model.fuse()

--- a/train.py
+++ b/train.py
@@ -261,7 +261,7 @@ def train(hyp, opt, device, callbacks):  # hyp is path/to/hyp.yaml or hyp dictio
     # DP mode
     if cuda and RANK == -1 and torch.cuda.device_count() > 1:
         LOGGER.warning(
-            "WARNING ⚠️ DP not recommended, use torch.distributed.run for best DDP Multi-GPU results.\n"
+            "DP not recommended, use torch.distributed.run for best DDP Multi-GPU results.\n"
             "See Multi-GPU Tutorial at https://docs.ultralytics.com/yolov5/tutorials/multi_gpu_training to get started."
         )
         model = torch.nn.DataParallel(model)

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -38,5 +38,5 @@ def notebook_init(verbose=True):
         s = ""
 
     select_device(newline=False)
-    LOGGER.info(emojis(f"Setup complete ✅ {s}"))
+    LOGGER.info(f"Setup complete ✅ {s}")
     return display

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -3,29 +3,12 @@
 
 import contextlib
 
-from ultralytics.utils import emojis, threaded  # noqa: F401
-
-
-class TryExcept(contextlib.ContextDecorator):
-    """A context manager and decorator for handling exceptions with optional custom messages."""
-
-    def __init__(self, msg=""):
-        """Initialize with an optional message prefixed to any caught exception when printed."""
-        self.msg = msg
-
-    def __enter__(self):
-        """Enter the exception-handling block (no setup required)."""
-
-    def __exit__(self, exc_type, value, traceback):
-        """Print the message and exception on exit, suppressing the exception so execution continues."""
-        if value:
-            print(emojis(f"{self.msg}{': ' if self.msg else ''}{value}"))
-        return True
+from ultralytics.utils import LOGGER, TryExcept, emojis, threaded  # noqa: F401
 
 
 def notebook_init(verbose=True):
     """Initializes notebook environment by checking hardware, software requirements, and cleaning up if in Colab."""
-    print("Checking setup...")
+    LOGGER.info("Checking setup...")
 
     import os
     import shutil
@@ -55,5 +38,5 @@ def notebook_init(verbose=True):
         s = ""
 
     select_device(newline=False)
-    print(emojis(f"Setup complete ✅ {s}"))
+    LOGGER.info(emojis(f"Setup complete ✅ {s}"))
     return display

--- a/utils/autoanchor.py
+++ b/utils/autoanchor.py
@@ -23,7 +23,7 @@ def check_anchor_order(m):
         m.anchors[:] = m.anchors.flip(0)
 
 
-@TryExcept(f"{PREFIX}ERROR")
+@TryExcept(PREFIX.rstrip())
 def check_anchors(dataset, model, thr=4.0, imgsz=640):
     """Evaluate anchor fit to a dataset and recompute anchors with k-means if best possible recall is too low."""
     m = model.module.model[-1] if hasattr(model, "module") else model.model[-1]  # Detect()
@@ -129,7 +129,7 @@ def kmean_anchors(dataset="./data/coco128.yaml", n=9, img_size=640, thr=4.0, gen
     # Filter
     i = (wh0 < 3.0).any(1).sum()
     if i:
-        LOGGER.info(f"{PREFIX}WARNING ⚠️ Extremely small objects found: {i} of {len(wh0)} labels are <3 pixels in size")
+        LOGGER.warning(f"{PREFIX}Extremely small objects found: {i} of {len(wh0)} labels are <3 pixels in size")
     wh = wh0[(wh0 >= 2.0).any(1)].astype(np.float32)  # filter > 2 pixels
     # wh = wh * (npr.rand(wh.shape[0], 1) * 0.9 + 0.1)  # multiply by random scale 0-1
 
@@ -141,7 +141,7 @@ def kmean_anchors(dataset="./data/coco128.yaml", n=9, img_size=640, thr=4.0, gen
         k = kmeans(wh / s, n, iter=30)[0] * s  # points
         assert n == len(k)  # kmeans may return fewer points than requested if wh is insufficient or too similar
     except Exception:
-        LOGGER.warning(f"{PREFIX}WARNING ⚠️ switching strategies from kmeans to random init")
+        LOGGER.warning(f"{PREFIX}switching strategies from kmeans to random init")
         k = np.sort(npr.rand(n * 2)).reshape(n, 2) * img_size  # random init
     wh, wh0 = (torch.tensor(x, dtype=torch.float32) for x in (wh, wh0))
     k = print_results(k, verbose=False)

--- a/utils/autoanchor.py
+++ b/utils/autoanchor.py
@@ -23,7 +23,7 @@ def check_anchor_order(m):
         m.anchors[:] = m.anchors.flip(0)
 
 
-@TryExcept(PREFIX.rstrip())
+@TryExcept(colorstr("AutoAnchor"))
 def check_anchors(dataset, model, thr=4.0, imgsz=640):
     """Evaluate anchor fit to a dataset and recompute anchors with k-means if best possible recall is too low."""
     m = model.module.model[-1] if hasattr(model, "module") else model.model[-1]  # Detect()

--- a/utils/autobatch.py
+++ b/utils/autobatch.py
@@ -43,7 +43,7 @@ def autobatch(model, imgsz=640, fraction=0.8, batch_size=16):
         LOGGER.info(f"{prefix}CUDA not detected, using default CPU batch-size {batch_size}")
         return batch_size
     if torch.backends.cudnn.benchmark:
-        LOGGER.info(f"{prefix} ⚠️ Requires torch.backends.cudnn.benchmark=False, using default batch-size {batch_size}")
+        LOGGER.warning(f"{prefix}Requires torch.backends.cudnn.benchmark=False, using default batch-size {batch_size}")
         return batch_size
 
     # Inspect CUDA memory
@@ -75,7 +75,7 @@ def autobatch(model, imgsz=640, fraction=0.8, batch_size=16):
             b = batch_sizes[max(i - 1, 0)]  # select prior safe point
     if b < 1 or b > 1024:  # b outside of safe range
         b = batch_size
-        LOGGER.warning(f"{prefix}WARNING ⚠️ CUDA anomaly detected, recommend restart environment and retry command.")
+        LOGGER.warning(f"{prefix}CUDA anomaly detected, recommend restart environment and retry command.")
 
     fraction = (np.polyval(p, b) + r + a) / t  # actual fraction predicted
     LOGGER.info(f"{prefix}Using batch-size {b} for {d} {t * fraction:.2f}G/{t:.2f}G ({fraction * 100:.0f}%) ✅")

--- a/utils/dataloaders.py
+++ b/utils/dataloaders.py
@@ -91,7 +91,7 @@ def create_dataloader(
 ):
     """Creates a DataLoader for training, with options for augmentation, caching, and parallelization."""
     if rect and shuffle:
-        LOGGER.warning("WARNING ⚠️ --rect is incompatible with DataLoader shuffle, setting shuffle=False")
+        LOGGER.warning("--rect is incompatible with DataLoader shuffle, setting shuffle=False")
         shuffle = False
     with torch_distributed_zero_first(rank):  # init dataset *.cache only once if DDP
         dataset = LoadImagesAndLabels(
@@ -382,7 +382,7 @@ class LoadStreams:
         self.auto = auto and self.rect
         self.transforms = transforms  # optional
         if not self.rect:
-            LOGGER.warning("WARNING ⚠️ Stream shapes differ. For optimal performance supply similarly-shaped streams.")
+            LOGGER.warning("Stream shapes differ. For optimal performance supply similarly-shaped streams.")
 
     def update(self, i, cap, stream):
         """Reads frames from stream `i` into `self.imgs` at intervals defined by `self.vid_stride`, handling
@@ -397,7 +397,7 @@ class LoadStreams:
                 if success:
                     self.imgs[i] = im
                 else:
-                    LOGGER.warning("WARNING ⚠️ Video stream unresponsive, please check your IP camera connection.")
+                    LOGGER.warning("Video stream unresponsive, please check your IP camera connection.")
                     self.imgs[i] = np.zeros_like(self.imgs[i])
                     cap.open(stream)  # re-open stream if signal was lost
             time.sleep(0.0)  # wait time
@@ -633,7 +633,7 @@ class LoadImagesAndLabels(Dataset):
         if msgs:
             LOGGER.info("\n".join(msgs))
         if nf == 0:
-            LOGGER.warning(f"{prefix}WARNING ⚠️ No labels found in {path}. {HELP_URL}")
+            LOGGER.warning(f"{prefix}No labels found in {path}. {HELP_URL}")
         x["hash"] = get_hash(self.label_files + self.im_files)
         x["results"] = nf, nm, ne, nc, len(self.im_files)
         x["msgs"] = msgs  # warnings
@@ -643,7 +643,7 @@ class LoadImagesAndLabels(Dataset):
             path.with_suffix(".cache.npy").rename(path)  # remove .npy suffix
             LOGGER.info(f"{prefix}New cache created: {path}")
         except Exception as e:
-            LOGGER.warning(f"{prefix}WARNING ⚠️ Cache directory {path.parent} is not writeable: {e}")  # not writeable
+            LOGGER.warning(f"{prefix}Cache directory {path.parent} is not writeable: {e}")  # not writeable
         return x
 
     def __len__(self):

--- a/utils/downloads.py
+++ b/utils/downloads.py
@@ -67,14 +67,14 @@ def safe_download(file, url, url2=None, min_bytes=1e0, error_msg=""):
     except Exception as e:  # url2
         if file.exists():
             file.unlink()  # remove partial downloads
-        LOGGER.info(f"ERROR: {e}\nRe-attempting {url2 or url} to {file}...")
+        LOGGER.warning(f"{e}\nRe-attempting {url2 or url} to {file}...")
         # curl download, retry and resume on fail
         curl_download(url2 or url, file)
     finally:
         if not file.exists() or file.stat().st_size < min_bytes:  # check
             if file.exists():
                 file.unlink()  # remove partial downloads
-            LOGGER.info(f"ERROR: {assert_msg}\n{error_msg}")
+            LOGGER.error(f"{assert_msg}\n{error_msg}")
         LOGGER.info("")
 
 

--- a/utils/general.py
+++ b/utils/general.py
@@ -451,7 +451,7 @@ def check_amp(model):
         return True
     except Exception:
         help_url = "https://docs.ultralytics.com/guides/yolo-common-issues/"
-        LOGGER.warning(f"{prefix}checks failed ❌, disabling Automatic Mixed Precision. See {help_url}")
+        LOGGER.warning(f"{prefix}checks failed, disabling Automatic Mixed Precision. See {help_url}")
         return False
 
 

--- a/utils/general.py
+++ b/utils/general.py
@@ -32,7 +32,7 @@ import yaml
 from ultralytics.data.converter import coco80_to_coco91_class  # noqa: F401
 from ultralytics.utils import (  # noqa: F401
     LOGGER,
-    TQDM,  # noqa: F401
+    TQDM,
     colorstr,
     get_default_args,
 )

--- a/utils/general.py
+++ b/utils/general.py
@@ -6,8 +6,6 @@ from __future__ import annotations
 import contextlib
 import glob
 import inspect
-import logging
-import logging.config
 import os
 import platform
 import random
@@ -18,7 +16,6 @@ import sys
 import time
 import urllib
 from copy import deepcopy
-from functools import partial
 from itertools import repeat
 from multiprocessing.pool import ThreadPool
 from pathlib import Path
@@ -33,8 +30,12 @@ import torch
 import torchvision
 import yaml
 from ultralytics.data.converter import coco80_to_coco91_class  # noqa: F401
-from ultralytics.utils import TQDM as _TQDM
-from ultralytics.utils import colorstr, get_default_args  # noqa: F401
+from ultralytics.utils import (  # noqa: F401
+    LOGGER,
+    TQDM,  # noqa: F401
+    colorstr,
+    get_default_args,
+)
 from ultralytics.utils.checks import check_requirements as check_requirements_ultralytics
 from ultralytics.utils.checks import check_version as check_version_ultralytics
 from ultralytics.utils.checks import is_ascii, print_args  # noqa: F401
@@ -65,8 +66,6 @@ RANK = int(os.getenv("RANK", "-1"))
 NUM_THREADS = min(8, max(1, os.cpu_count() - 1))  # number of YOLOv3 multiprocessing threads
 DATASETS_DIR = Path(os.getenv("YOLOv3_DATASETS_DIR", ROOT.parent / "datasets"))  # global datasets directory
 AUTOINSTALL = str(os.getenv("YOLOv3_AUTOINSTALL", "true")).lower() == "true"  # global auto-install mode
-VERBOSE = str(os.getenv("YOLOv3_VERBOSE", "true")).lower() == "true"  # global verbose mode
-TQDM = partial(_TQDM, file=sys.stderr)  # progress bars on stderr like LOGGER, keeping stdout free for piped output
 FONT = "Arial.ttf"  # https://github.com/ultralytics/assets/releases/download/v0.0.0/Arial.ttf
 
 torch.set_printoptions(linewidth=320, precision=5, profile="long")
@@ -137,43 +136,6 @@ def is_writeable(dir, test=False):
         return True
     except OSError:
         return False
-
-
-LOGGING_NAME = "yolov3"
-
-
-def set_logging(name=LOGGING_NAME, verbose=True):
-    """Configures logging with specified verbosity; 'name' sets logger identity, 'verbose' toggles logging level."""
-    rank = int(os.getenv("RANK", "-1"))  # rank in world for Multi-GPU trainings
-    level = logging.INFO if verbose and rank in {-1, 0} else logging.ERROR
-    logging.config.dictConfig(
-        {
-            "version": 1,
-            "disable_existing_loggers": False,
-            "formatters": {name: {"format": "%(message)s"}},
-            "handlers": {
-                name: {
-                    "class": "logging.StreamHandler",
-                    "formatter": name,
-                    "level": level,
-                }
-            },
-            "loggers": {
-                name: {
-                    "level": level,
-                    "handlers": [name],
-                    "propagate": False,
-                }
-            },
-        }
-    )
-
-
-set_logging(LOGGING_NAME)  # run before defining LOGGER
-LOGGER = logging.getLogger(LOGGING_NAME)  # define globally (used in train.py, val.py, detect.py, etc.)
-if platform.system() == "Windows":
-    for fn in LOGGER.info, LOGGER.warning:
-        setattr(LOGGER, fn.__name__, lambda x, fn=fn: fn(emojis(x)))  # emoji safe logging
 
 
 def user_config_dir(dir="Ultralytics", env_var="YOLOV3_CONFIG_DIR"):
@@ -326,7 +288,7 @@ def check_img_size(imgsz, s=32, floor=0):
         imgsz = list(imgsz)  # convert to list if tuple
         new_size = [max(make_divisible(x, int(s)), floor) for x in imgsz]
     if new_size != imgsz:
-        LOGGER.warning(f"WARNING ⚠️ --img-size {imgsz} must be multiple of max stride {s}, updating to {new_size}")
+        LOGGER.warning(f"--img-size {imgsz} must be multiple of max stride {s}, updating to {new_size}")
     return new_size
 
 
@@ -342,7 +304,7 @@ def check_imshow(warn=False):
         return True
     except Exception as e:
         if warn:
-            LOGGER.warning(f"WARNING ⚠️ Environment does not support cv2.imshow() or PIL Image.show()\n{e}")
+            LOGGER.warning(f"Environment does not support cv2.imshow() or PIL Image.show()\n{e}")
         return False
 
 
@@ -545,9 +507,9 @@ def download(url, dir=".", unzip=True, delete=True, curl=False, threads=1, retry
                 if success:
                     break
                 elif i < retry:
-                    LOGGER.warning(f"⚠️ Download failure, retrying {i + 1}/{retry} {url}...")
+                    LOGGER.warning(f"Download failure, retrying {i + 1}/{retry} {url}...")
                 else:
-                    LOGGER.warning(f"❌ Failed to download {url}...")
+                    LOGGER.warning(f"Failed to download {url}...")
 
         if unzip and success and (f.suffix == ".gz" or is_zipfile(f) or is_tarfile(f)):
             LOGGER.info(f"Unzipping {f}...")
@@ -782,7 +744,7 @@ def non_max_suppression(
         if mps:
             output[xi] = output[xi].to(device)
         if (time.time() - t) > time_limit:
-            LOGGER.warning(f"WARNING ⚠️ NMS time limit {time_limit:.3f}s exceeded")
+            LOGGER.warning(f"NMS time limit {time_limit:.3f}s exceeded")
             break  # time limit exceeded
 
     return output

--- a/utils/loggers/__init__.py
+++ b/utils/loggers/__init__.py
@@ -119,7 +119,7 @@ class Loggers:
                 self.clearml = None
                 prefix = colorstr("ClearML: ")
                 LOGGER.warning(
-                    f"{prefix}WARNING ⚠️ ClearML is installed but not configured, skipping ClearML logging."
+                    f"{prefix}ClearML is installed but not configured, skipping ClearML logging."
                     f" See https://docs.ultralytics.com/yolov5/tutorials/clearml_logging_integration#readme"
                 )
 
@@ -415,7 +415,7 @@ def log_tensorboard_graph(tb, model, imgsz=(640, 640)):
             warnings.simplefilter("ignore")  # suppress jit trace warning
             tb.add_graph(torch.jit.trace(de_parallel(model), im, strict=False), [])
     except Exception as e:
-        LOGGER.warning(f"WARNING ⚠️ TensorBoard graph visualization failure {e}")
+        LOGGER.warning(f"TensorBoard graph visualization failure {e}")
 
 
 def web_project_name(project):

--- a/utils/loggers/clearml/hpo.py
+++ b/utils/loggers/clearml/hpo.py
@@ -7,6 +7,7 @@ from clearml import Task
 # from here on everything is logged automatically
 from clearml.automation import HyperParameterOptimizer, UniformParameterRange
 from clearml.automation.optuna import OptimizerOptuna
+from ultralytics.utils import LOGGER
 
 task = Task.init(
     project_name="Hyper-Parameter Optimization",
@@ -88,4 +89,4 @@ optimizer.wait()
 # make sure background optimization stopped
 optimizer.stop()
 
-print("We are done, good bye")
+LOGGER.info("We are done, good bye")

--- a/utils/loggers/clearml/hpo.py
+++ b/utils/loggers/clearml/hpo.py
@@ -7,7 +7,6 @@ from clearml import Task
 # from here on everything is logged automatically
 from clearml.automation import HyperParameterOptimizer, UniformParameterRange
 from clearml.automation.optuna import OptimizerOptuna
-from ultralytics.utils import LOGGER
 
 task = Task.init(
     project_name="Hyper-Parameter Optimization",
@@ -88,5 +87,3 @@ optimizer.start_locally()
 optimizer.wait()
 # make sure background optimization stopped
 optimizer.stop()
-
-LOGGER.info("We are done, good bye")

--- a/utils/loggers/wandb/wandb_utils.py
+++ b/utils/loggers/wandb/wandb_utils.py
@@ -18,7 +18,7 @@ if str(ROOT) not in sys.path:
     sys.path.append(str(ROOT))  # add ROOT to PATH
 RANK = int(os.getenv("RANK", "-1"))
 DEPRECATION_WARNING = (
-    f"{colorstr('wandb')}: WARNING ⚠️ wandb is deprecated and will be removed in a future release. "
+    f"{colorstr('wandb')}: wandb is deprecated and will be removed in a future release. "
     f"See supported integrations at https://github.com/ultralytics/yolov3#integrations."
 )
 

--- a/utils/metrics.py
+++ b/utils/metrics.py
@@ -7,10 +7,9 @@ from pathlib import Path
 import matplotlib.pyplot as plt
 import numpy as np
 import torch
-from ultralytics.utils import LOGGER
 from ultralytics.utils.metrics import box_iou, plot_mc_curve, plot_pr_curve, smooth
 
-from utils import TryExcept
+from utils import LOGGER, TryExcept
 
 
 def fitness(x):

--- a/utils/metrics.py
+++ b/utils/metrics.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import matplotlib.pyplot as plt
 import numpy as np
 import torch
+from ultralytics.utils import LOGGER
 from ultralytics.utils.metrics import box_iou, plot_mc_curve, plot_pr_curve, smooth
 
 from utils import TryExcept
@@ -184,7 +185,7 @@ class ConfusionMatrix:
         # fn = self.matrix.sum(0) - tp  # false negatives (missed detections)
         return tp[:-1], fp[:-1]  # remove background class
 
-    @TryExcept("WARNING ⚠️ ConfusionMatrix plot failure")
+    @TryExcept("ConfusionMatrix plot failure")
     def plot(self, normalize=True, save_dir="", names=()):
         """Plots confusion matrix as a heatmap; args: normalize(bool), save_dir(str), names(iterable of str)."""
         import seaborn as sn
@@ -220,4 +221,4 @@ class ConfusionMatrix:
     def print(self):
         """Prints each row of the confusion matrix, where matrix elements are separated by spaces."""
         for i in range(self.nc + 1):
-            print(" ".join(map(str, self.matrix[i])))
+            LOGGER.info(" ".join(map(str, self.matrix[i])))

--- a/utils/plots.py
+++ b/utils/plots.py
@@ -190,7 +190,7 @@ def plot_val_study(file="", dir="", x=None):  # from utils.plots import *; plot_
     ax2.set_ylabel("COCO AP val")
     ax2.legend(loc="lower right")
     f = save_dir / "study.png"
-    print(f"Saving {f}...")
+    LOGGER.info(f"Saving {f}...")
     plt.savefig(f, dpi=300)
 
 
@@ -250,7 +250,7 @@ def plot_evolve(evolve_csv="path/to/evolve.csv"):  # from utils.plots import *; 
     j = np.argmax(f)  # max fitness index
     plt.figure(figsize=(10, 12), tight_layout=True)
     matplotlib.rc("font", size=8)
-    print(f"Best results from row {j} of {evolve_csv}:")
+    LOGGER.info(f"Best results from row {j} of {evolve_csv}:")
     for i, k in enumerate(keys[7:]):
         v = x[:, 7 + i]
         mu = v[j]  # best single result
@@ -260,11 +260,11 @@ def plot_evolve(evolve_csv="path/to/evolve.csv"):  # from utils.plots import *; 
         plt.title(f"{k} = {mu:.3g}", fontdict={"size": 9})
         if i % 5 != 0:
             plt.yticks([])
-        print(f"{k:>15}: {mu:.3g}")
+        LOGGER.info(f"{k:>15}: {mu:.3g}")
     f = evolve_csv.with_suffix(".png")  # filename
     plt.savefig(f, dpi=200)
     plt.close()
-    print(f"Saved {f}")
+    LOGGER.info(f"Saved {f}")
 
 
 def plot_results(file="path/to/results.csv", dir=""):

--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -53,7 +53,7 @@ def smartCrossEntropyLoss(label_smoothing=0.0):
     if check_version(torch.__version__, "1.10.0"):
         return nn.CrossEntropyLoss(label_smoothing=label_smoothing)
     if label_smoothing > 0:
-        LOGGER.warning(f"WARNING ⚠️ label smoothing {label_smoothing} requires torch>=1.10.0")
+        LOGGER.warning(f"label smoothing {label_smoothing} requires torch>=1.10.0")
     return nn.CrossEntropyLoss()
 
 
@@ -132,7 +132,7 @@ def profile(input, ops, n=10, device=None):
     results = []
     if not isinstance(device, torch.device):
         device = select_device(device)
-    print(
+    LOGGER.info(
         f"{'Params':>12s}{'GFLOPs':>12s}{'GPU_mem (GB)':>14s}{'forward (ms)':>14s}{'backward (ms)':>14s}"
         f"{'input':>24s}{'output':>24s}"
     )
@@ -165,10 +165,10 @@ def profile(input, ops, n=10, device=None):
                 mem = torch.cuda.memory_reserved() / 1e9 if torch.cuda.is_available() else 0  # (GB)
                 s_in, s_out = (tuple(x.shape) if isinstance(x, torch.Tensor) else "list" for x in (x, y))  # shapes
                 p = sum(x.numel() for x in m.parameters()) if isinstance(m, nn.Module) else 0  # parameters
-                print(f"{p:12}{flops:12.4g}{mem:>14.3f}{tf:14.4g}{tb:14.4g}{s_in!s:>24s}{s_out!s:>24s}")
+                LOGGER.info(f"{p:12}{flops:12.4g}{mem:>14.3f}{tf:14.4g}{tb:14.4g}{s_in!s:>24s}{s_out!s:>24s}")
                 results.append([p, flops, mem, tf, tb, s_in, s_out])
             except Exception as e:
-                print(e)
+                LOGGER.error(e)
                 results.append(None)
             torch.cuda.empty_cache()
     return results

--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -168,7 +168,7 @@ def profile(input, ops, n=10, device=None):
                 LOGGER.info(f"{p:12}{flops:12.4g}{mem:>14.3f}{tf:14.4g}{tb:14.4g}{s_in!s:>24s}{s_out!s:>24s}")
                 results.append([p, flops, mem, tf, tb, s_in, s_out])
             except Exception as e:
-                LOGGER.error(e)
+                LOGGER.warning(e)
                 results.append(None)
             torch.cuda.empty_cache()
     return results

--- a/val.py
+++ b/val.py
@@ -432,7 +432,7 @@ def run(
     pf = "%22s" + "%11i" * 2 + "%11.3g" * 4  # print format
     LOGGER.info(pf % ("all", seen, nt.sum(), mp, mr, map50, map))
     if nt.sum() == 0:
-        LOGGER.warning(f"WARNING ⚠️ no labels found in {task} set, can not compute metrics without labels")
+        LOGGER.warning(f"no labels found in {task} set, can not compute metrics without labels")
 
     # Print results per class
     if (verbose or (nc < 50 and not training)) and nc > 1 and len(stats):
@@ -594,9 +594,9 @@ def main(opt):
 
     if opt.task in ("train", "val", "test"):  # run normally
         if opt.conf_thres > 0.001:  # https://github.com/ultralytics/yolov5/issues/1466
-            LOGGER.info(f"WARNING ⚠️ confidence threshold {opt.conf_thres} > 0.001 produces invalid results")
+            LOGGER.warning(f"confidence threshold {opt.conf_thres} > 0.001 produces invalid results")
         if opt.save_hybrid:
-            LOGGER.info("WARNING ⚠️ --save-hybrid will return high mAP from hybrid labels, not from predictions alone")
+            LOGGER.warning("--save-hybrid will return high mAP from hybrid labels, not from predictions alone")
         run(**vars(opt))
 
     else:


### PR DESCRIPTION
Mirrors ultralytics/yolov5#13840. This repo has no ndjson feature, so it needs no prerequisite.

### The logger

`utils/general.py` configured its own `"yolov3"` logger via `logging.config.dictConfig` and exported it. `LOGGING_NAME`, `set_logging`, the module-scope call, the `LOGGER` assignment and the Windows-only emoji monkeypatch are deleted in favour of one name on the existing `from ultralytics.utils import ...` line. `set_logging` had **zero external callers**.

Two quiet fixes come with it: the Windows patch only wrapped `info`/`warning`, so `LOGGER.error` was never emoji-safe; and `dictConfig` ran at import time and cleared every handler registered before it — including ultralytics' own.

### `TryExcept` deduped

`utils/__init__.py`'s local `TryExcept` is replaced by ultralytics', as yolov5 did in #13832. This matters beyond the line count: the local `__exit__` used a bare `print()`, while upstream's routes through `LOGGER.warning`. That flips the two `@TryExcept(...)` decorator messages from *keep the marker* to *strip it* — `@TryExcept("WARNING ⚠️ ConfusionMatrix plot failure")` would otherwise have printed the marker twice. Verified:

```
WARNING ⚠️ ConfusionMatrix plot failure: boom
```

`@TryExcept(f"{PREFIX}ERROR")` in `autoanchor.py` gets the same treatment — it would have read `WARNING ⚠️ AutoAnchor: ERROR: <exc>`.

### Progress bars rejoin the log stream

`TQDM = partial(_TQDM, file=sys.stderr)` is dropped — ultralytics' `TQDM` already defaults to `sys.stdout`, where `LOGGER` now writes, so the val table header and its metric rows are back on one ordered stream. Dead `VERBOSE` (`YOLOv3_VERBOSE`, no readers) goes with it; verbosity is `YOLO_VERBOSE` now.

### The marker sweep

**22 stripped**, **6 promoted** from `LOGGER.info` to `.warning`/`.error` first. Four of the stripped sites had no `WARNING` word and so were invisible to a fixed-prefix grep — the download retry/failure pair in `utils/general.py`, the bare `⚠️` in `autobatch.py`, and the non-emoji `ERROR:` in `downloads.py`.

Anything that does not reach `LOGGER.warning` keeps its literal: `verify_image_label` messages accumulated into `msgs` and emitted by a single `LOGGER.info("\n".join(...))` (and persisted into `*.cache`, so old caches replay them), assert and `raise` messages, `utils/loggers/comet/*`'s module-private `logging.getLogger(__name__)`, and the ✅/❌ **status** pairs like `checks passed ✅` / `checks failed ❌`, which indicate outcome rather than severity.

Unlike yolov5 this repo needed **no `check_version` split** — it is already a one-line delegation to the ultralytics checker.

### `hubconf.py`

It imported stdlib `logging` **through** `utils.general`; deleting `set_logging` orphans that import and the `ruff --fix` Ultralytics Actions pushes would have stripped it, breaking `torch.hub` loading. It now imports `logging` directly and saves/restores `LOGGER.level` instead of forcing `INFO`, since the logger is shared with ultralytics.

### `print()` → `LOGGER`

All 16 remaining bare calls, at the appropriate level — `profile()`'s table and `plot_evolve()`'s rows to `.info`, `models/yolo.py`'s config error and `profile()`'s exception to `.error`, and `export.py`'s CoreML pipeline prose (which was writing to stdout while the log went to stderr, so this actually merges them into one ordered stream). `utils/metrics.py` imports `LOGGER` straight from ultralytics rather than `utils.general`, which would be circular.

**Zero bare `print()` calls remain** (AST-verified, not grep).

### Validation

| check | result |
|---|---|
| `val.py --weights yolov3-tiny.pt --data coco128.yaml --img 640` | `all 128 929 0.537 0.43 0.472 0.259` — unchanged |
| doubled marker in a real run | **0 occurrences** |
| `TryExcept` | still reports, now via `LOGGER.warning`, single marker |
| `hubconf._create(verbose=False)` | `LOGGER.level` 20 → 20, restored |
| `val.py` streams | full log on stdout, **0 bytes** on stderr |
| `train.py`, `detect.py` | pass |
| `ruff check .` / `--select I` / `format --check` | clean |

**Behaviour change to call out: log output moves from stderr to stdout.** At `f"{prefix}WARNING ⚠️ …"` sites the auto-prefix now lands outside the `colorstr` prefix, so `AutoAnchor: WARNING ⚠️ msg` reads `WARNING ⚠️ AutoAnchor: msg`.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🛠️ Standardizes YOLOv3 output through the shared Ultralytics logger, improving message consistency and logging reliability.

### 📊 Key Changes

- Replaced direct `print()` calls with `LOGGER.info()`, `LOGGER.warning()`, and `LOGGER.error()` across export, training, validation, plotting, profiling, and notebook utilities.
- Removed duplicated warning prefixes and emojis from log messages, allowing logger levels to communicate message severity.
- Updated `utils/__init__.py` to reuse Ultralytics’ shared `LOGGER` and `TryExcept` implementations.
- Removed YOLOv3’s local logging configuration and delegated logging behavior to the Ultralytics utilities.
- Fixed `hubconf.py` to restore the logger’s previous level on both successful and failed model-loading paths.
- Improved severity levels for download failures, CoreML quantization limitations, validation issues, and profiling errors.
- Removed an unnecessary completion message from the ClearML HPO script.

### 🎯 Purpose & Impact

- 📋 Provides cleaner, more consistent logs across the entire YOLOv3 codebase.
- 🔧 Makes logging easier to configure and integrate with external tools or applications.
- 🧩 Prevents shared logger settings from being left in an unintended state when loading models.
- 🚦 Ensures warnings and errors are categorized correctly, improving readability and automated log monitoring.
- ✅ Preserves existing training, inference, export, and evaluation behavior while improving developer and user experience.