### PR TITLE
Remove dead pyproject tables and docs tooling this repo does not use

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,7 @@ Pretrained weights download from the GitHub release `v9.6.0` assets via `utils/d
 
 - The default branch is `master`, not `main` — target PRs at `master`.
 - Ultralytics Actions (`format.yml`) auto-formats PRs (Ruff, docformatter, codespell, prettier) and adds the `# Ultralytics 🚀 AGPL-3.0 License` header — never add or revert headers or formatting manually.
-- Google-style docstrings, 120-char lines (Ruff/isort/docformatter all configured in `pyproject.toml`); every larger class and function needs a Google-style docstring (Args/Returns sections), while a one-line summary suffices for small helpers.
+- Google-style docstrings, 120-char lines (Ruff and docformatter both configured in `pyproject.toml`); every larger class and function needs a Google-style docstring (Args/Returns sections), while a one-line summary suffices for small helpers.
 - The CI smoke tests hit the live network: they download `yolov3-tiny.pt` from the v9.6.0 release and the coco128 dataset from `github.com/ultralytics/assets`.
 - Keep `requirements.txt` and `pyproject.toml` dependency floors aligned — Dependabot bumps both (monthly pip, weekly github-actions).
 - Links to `github.com/ultralytics/yolov5/(issues|pull|discussions)/<N>` are intentional upstream provenance — do not rewrite them to `yolov3` (those numbers 404 there). Bare yolov5 repo/tree/releases links were already rebranded.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,15 +82,9 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "ipython",
-    "check-manifest",
-    "pre-commit",
     "pytest",
     "pytest-cov",
     "coverage[toml]",
-    "mkdocs-material",
-    "mkdocstrings[python]",
-    "mkdocs-redirects", # for 301 redirects
-    "mkdocs-ultralytics-plugin>=0.2.5", # for meta descriptions and images, dates and authors
 ]
 export = [
     "onnx>=1.12.0", # ONNX export
@@ -117,14 +111,6 @@ extra = [
 "Source" = "https://github.com/ultralytics/yolov3/"
 
 # Tools settings -------------------------------------------------------------------------------------------------------
-[tool.pytest]
-norecursedirs = [".git", "dist", "build"]
-addopts = "--doctest-modules --durations=30 --color=yes"
-
-[tool.isort]
-line_length = 120
-multi_line_output = 0
-
 [tool.ruff]
 line-length = 120
 
@@ -146,5 +132,5 @@ pre-summary-newline = true
 close-quotes-on-newline = true
 
 [tool.codespell]
-ignore-words-list = "crate,nd,strack,dota,ane,segway,fo,gool,winn,commend"
-skip = '*.csv,*venv*,docs/??/,docs/mkdocs_??.yml'
+ignore-words-list = "nd,writeable"
+skip = '*venv*'


### PR DESCRIPTION
`pyproject.toml` cleanup — every item below was copied from `ultralytics/ultralytics` and never adapted:

- `[tool.pytest]` is a dead table: pytest only reads `[tool.pytest.ini_options]`, so its `norecursedirs` and `addopts` have never taken effect. This repo also has no test suite (CI smoke-tests the scripts), so the table is deleted rather than renamed.
- `[tool.isort]`: nothing runs isort. Import sorting comes from Ruff, already configured below it. Updated the matching AGENTS.md line, which claimed isort was configured here.
- `dev` extra: dropped the four `mkdocs-*` entries (no `docs/` tree and no `mkdocs.yml` in this repo), `check-manifest` (no `MANIFEST.in`), and `pre-commit` (no `.pre-commit-config.yaml`) — none can do anything without the config files they require.
- `[tool.codespell]`: `skip` pointed at `docs/??/`, `docs/mkdocs_??.yml`, and `*.csv`, none of which exist here. The `ignore-words-list` was the YOLO-package list; running codespell with the Actions dictionaries against a clean checkout flags only `nd` and `writeable`, and `writeable` was missing — a bare local `codespell` reported false positives that CI hid because the Action passes its own `--ignore-words-list`. `codespell` from the repo root is now clean with no extra flags.

Dependencies for the shipped code, classifiers, version, and `requires-python` are untouched; `openvino-dev>=2023.0` stays because `export.py` itself calls `check_requirements("openvino-dev>=2023.0")`.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Streamlines development configuration by removing outdated tooling dependencies and simplifying linting and spell-check settings. 🧹

### 📊 Key Changes

- Removed unused development dependencies, including:
  - `check-manifest`
  - `pre-commit`
  - MkDocs documentation packages
- Removed obsolete `pytest` and `isort` configuration blocks from `pyproject.toml`.
- Updated contributor guidance to reflect that Ruff and docformatter handle formatting.
- Simplified codespell settings by reducing ignored words and removing documentation-specific exclusions.

### 🎯 Purpose & Impact

- Reduces development-environment complexity and unnecessary package installation. ⚡
- Keeps project configuration aligned with the tools currently used in CI and automated formatting.
- May require contributors to update local workflows if they relied on the removed documentation or pre-commit dependencies.
- Does not change YOLOv3 runtime behavior, training, inference, or exported models. ✅